### PR TITLE
[Freddie] AcceptanceTestBase에 RestAssured용 ObjectMapper 설정 추가

### DIFF
--- a/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
+++ b/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
@@ -1,5 +1,7 @@
 package com.postsquad.scoup.web;
 
+import io.restassured.internal.mapping.Jackson2Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 
@@ -10,4 +12,9 @@ public class AcceptanceTestBase {
 
     @LocalServerPort
     protected int port;
+
+    @Autowired
+    protected com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper;
+
+    protected io.restassured.mapper.ObjectMapper restAssuredObjectMapper = new Jackson2Mapper((type, charset) -> jacksonObjectMapper);
 }

--- a/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
+++ b/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
@@ -1,5 +1,9 @@
 package com.postsquad.scoup.web;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
 import io.restassured.internal.mapping.Jackson2Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,7 +18,17 @@ public class AcceptanceTestBase {
     protected int port;
 
     @Autowired
-    protected com.fasterxml.jackson.databind.ObjectMapper jacksonObjectMapper;
+    protected ObjectMapper objectMapper;
 
-    protected io.restassured.mapper.ObjectMapper restAssuredObjectMapper = new Jackson2Mapper((type, charset) -> jacksonObjectMapper);
+    {
+        setUpRestAssured();
+    }
+
+    private void setUpRestAssured() {
+        Jackson2Mapper jackson2Mapper = new Jackson2Mapper((type, charset) -> objectMapper);
+        ObjectMapperConfig jackson2ObjectMapperConfig = new ObjectMapperConfig(jackson2Mapper);
+
+        RestAssured.config = RestAssuredConfig.config()
+                .objectMapperConfig(jackson2ObjectMapperConfig);
+    }
 }

--- a/src/test/java/com/postsquad/scoup/web/user/controller/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/controller/UserAcceptanceTest.java
@@ -7,7 +7,6 @@ import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import io.restassured.internal.mapping.Jackson2Mapper;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
@@ -27,11 +26,6 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @Autowired
     UserRepository userRepository;
-
-    @Autowired
-    private com.fasterxml.jackson.databind.ObjectMapper objectMapperInner;
-
-    protected io.restassured.mapper.ObjectMapper objectMapper = new Jackson2Mapper((type, charset) -> objectMapperInner);
 
     @AfterEach
     void tearDown() {
@@ -108,7 +102,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
         actualResponse.then()
                 .log().all()
                 .statusCode(HttpStatus.BAD_REQUEST.value());
-        then(actualResponse.as(ErrorResponse.class, objectMapper))
+        then(actualResponse.as(ErrorResponse.class))
                 .as("회원가입 결과 : %s", description)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()


### PR DESCRIPTION
기존 방식 말고, 설정을 덮어씌우는 식으로 수정했습니다.

때문에 객체 변환을 할 때 ObjectMapper 주입을 따로 해주지 않아도 됩니다.