### PR TITLE
[새리][3-1-1] 그룹 생성

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -1,0 +1,21 @@
+package com.postsquad.scoup.web.group.controller;
+
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/groups")
+@RestController
+public class GroupController {
+
+    @GetMapping
+    public Long create(@RequestBody GroupCreationRequest groupCreationRequest) {
+        // dummy
+        return 1L;
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -6,6 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @RequiredArgsConstructor
 @RequestMapping("/groups")
 @RestController
@@ -15,7 +17,7 @@ public class GroupController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Long create(@RequestBody GroupCreationRequest groupCreationRequest) {
+    public Long create(@RequestBody @Valid GroupCreationRequest groupCreationRequest) {
         return groupService.create(groupCreationRequest);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -1,21 +1,21 @@
 package com.postsquad.scoup.web.group.controller;
 
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
-import com.postsquad.scoup.web.user.domain.User;
+import com.postsquad.scoup.web.group.service.GroupService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/groups")
 @RestController
 public class GroupController {
 
-    @GetMapping
+    private final GroupService groupService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     public Long create(@RequestBody GroupCreationRequest groupCreationRequest) {
-        // dummy
-        return 1L;
+        return groupService.create(groupCreationRequest);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupBaseRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupBaseRequest.java
@@ -1,10 +1,12 @@
 package com.postsquad.scoup.web.group.controller.request;
 
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 
-@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
 public class GroupBaseRequest {
 
     @NotEmpty

--- a/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupCreationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupCreationRequest.java
@@ -1,7 +1,16 @@
 package com.postsquad.scoup.web.group.controller.request;
 
-import lombok.Getter;
+import lombok.*;
 
-@Getter
+import javax.validation.constraints.NotEmpty;
+
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@Data
 public class GroupCreationRequest extends GroupBaseRequest {
+
+    @Builder
+    public GroupCreationRequest(@NotEmpty String name, String description) {
+        super(name, description);
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupCreationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupCreationRequest.java
@@ -4,8 +4,8 @@ import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 
-@EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class GroupCreationRequest extends GroupBaseRequest {
 

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -10,8 +10,7 @@ import javax.persistence.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Table(name = "GROUP_TABLE", // TODO: GROUP is reserved word, 팀원들과 상의 후 테이블 이름 결정
-       uniqueConstraints = {
+@Table(uniqueConstraints = {
         @UniqueConstraint(columnNames = {"name"}, name = "UK_GROUP_NAME"),
 })
 @Entity

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -1,0 +1,35 @@
+package com.postsquad.scoup.web.group.domain;
+
+import com.postsquad.scoup.web.common.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "GROUP_TABLE", // TODO: GROUP is reserved word, 팀원들과 상의 후 테이블 이름 결정
+       uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"name"}, name = "UK_GROUP_NAME"),
+})
+@Entity
+public class Group extends BaseEntity {
+
+    @Column
+    private String name;
+
+    @Column
+    private String description;
+
+    protected Group(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Builder
+    public static Group of(String name, String description) {
+        return new Group(name, description);
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -16,10 +16,10 @@ import javax.persistence.*;
 @Entity
 public class Group extends BaseEntity {
 
-    @Column
+    @Column(length = 20, nullable = false)
     private String name;
 
-    @Column
+    @Column(length = 200)
     private String description;
 
     protected Group(String name, String description) {

--- a/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
@@ -1,2 +1,14 @@
-package com.postsquad.scoup.web.group.mapper;public class GroupMapper {
+package com.postsquad.scoup.web.group.mapper;
+
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface GroupMapper {
+
+    GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
+
+    Group groupCreationRequestToGroup(GroupCreationRequest groupCreationRequest);
 }

--- a/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
@@ -1,0 +1,2 @@
+package com.postsquad.scoup.web.group.mapper;public class GroupMapper {
+}

--- a/src/main/java/com/postsquad/scoup/web/group/repository/GroupRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/group/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package com.postsquad.scoup.web.group.repository;
+
+import com.postsquad.scoup.web.group.domain.Group;
+import org.springframework.data.repository.CrudRepository;
+
+public interface GroupRepository extends CrudRepository<Group, Long> {
+}

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -1,0 +1,2 @@
+package com.postsquad.scoup.web.group.service;public class GroupService {
+}

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -1,2 +1,21 @@
-package com.postsquad.scoup.web.group.service;public class GroupService {
+package com.postsquad.scoup.web.group.service;
+
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import com.postsquad.scoup.web.group.mapper.GroupMapper;
+import com.postsquad.scoup.web.group.repository.GroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+
+    public Long create(GroupCreationRequest groupCreationRequest) {
+        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest);
+
+        return groupRepository.save(group).getId();
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,6 +18,7 @@ spring.h2.console.enabled=true
 #spring.jpa.defer-datasource-initialization=true
 spring.jpa.generate-ddl=true
 spring.sql.init.mode=embedded
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
 
 # logging
 # TODO: Logging

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
 import java.util.stream.Stream;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 public class GroupAcceptanceTest extends AcceptanceTestBase {
 
+    @Autowired
     GroupRepository groupRepository;
 
     @ParameterizedTest
@@ -44,7 +46,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
         actualResponse.then()
                       .log().all()
                       .statusCode(HttpStatus.CREATED.value());
-        then(groupRepository.findById(actualResponse.body().as(Long.class)))
+        then(groupRepository.findById(actualResponse.body().as(Long.class)).orElse(null))
                 .as("그룹 생성: %s", description)
                 .usingRecursiveComparison()
                 .ignoringFields(ignoringFieldsForResponseWithId)
@@ -56,7 +58,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "성공",
                         GroupCreationRequest.builder()
-                                            .name("group")
+                                            .name("name")
                                             .description("description")
                                             .build(),
                         Group.builder()

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -1,0 +1,69 @@
+package com.postsquad.scoup.web.group;
+
+import com.postsquad.scoup.web.AcceptanceTestBase;
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import com.postsquad.scoup.web.group.repository.GroupRepository;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class GroupAcceptanceTest extends AcceptanceTestBase {
+
+    GroupRepository groupRepository;
+
+    @ParameterizedTest
+    @MethodSource("createGroupProvider")
+    @DisplayName("사용자가 새로운 그룹을 생성할 수 있다.")
+    void createGroup(String description, GroupCreationRequest givenGroupCreationRequest, Group expectedGroup) {
+        // given
+        String path = "/api/groups";
+        RequestSpecification givenRequest = RestAssured.given()
+                                                       .baseUri(BASE_URL)
+                                                       .port(port)
+                                                       .basePath(path)
+                                                       .contentType(ContentType.JSON)
+                                                       .body(givenGroupCreationRequest);
+
+        // when
+        Response actualResponse = givenRequest.when()
+                                              .log().all()
+                                              .post();
+
+        // then
+        actualResponse.then()
+                      .log().all()
+                      .statusCode(HttpStatus.CREATED.value());
+        then(groupRepository.findById(actualResponse.body().as(Long.class)))
+                .as("그룹 생성: %s", description)
+                .usingRecursiveComparison()
+                .ignoringFields(ignoringFieldsForResponseWithId)
+                .isEqualTo(expectedGroup);
+    }
+
+    static Stream<Arguments> createGroupProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "성공",
+                        GroupCreationRequest.builder()
+                                            .name("group")
+                                            .description("description")
+                                            .build(),
+                        Group.builder()
+                             .name("name")
+                             .description("description")
+                             .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
@@ -1,0 +1,41 @@
+package com.postsquad.scoup.web.group.mapper;
+
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class GroupMapperTest {
+
+    @ParameterizedTest
+    @MethodSource("groupCreationRequestToGroupProvider")
+    void groupCreationRequestToGroup(GroupCreationRequest givenGroupCreationRequest, Group expectedGroup) {
+        // when
+        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(givenGroupCreationRequest);
+
+        // then
+        then(group).usingRecursiveComparison()
+                   .isEqualTo(expectedGroup);
+    }
+
+    static Stream<Arguments> groupCreationRequestToGroupProvider() {
+        return Stream.of(
+                Arguments.of(
+                        GroupCreationRequest.builder()
+                        .name("name")
+                        .description("description")
+                        .build(),
+                        Group.builder()
+                        .name("name")
+                        .description("description")
+                        .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/group/repository/GroupRepositoryTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/repository/GroupRepositoryTest.java
@@ -1,2 +1,96 @@
-package com.postsquad.scoup.web.group.repository;public class GroupRepositoryTest {
+package com.postsquad.scoup.web.group.repository;
+
+import com.postsquad.scoup.web.group.domain.Group;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+
+@DataJpaTest
+public class GroupRepositoryTest {
+
+    @Autowired
+    GroupRepository groupRepository;
+
+    @Test
+    void save() {
+        // given
+        Group group = Group.builder()
+                           .name("name")
+                           .description("description")
+                           .build();
+
+        // when
+        groupRepository.save(group);
+
+        // then
+        then(groupRepository.findById(group.getId()).get())
+                .isEqualTo(group);
+    }
+
+    @ParameterizedTest
+    @MethodSource("columnConstraintViolationProvider")
+    void databaseConstraintViolation(String description, Group givenGroup) {
+        // when
+        Throwable actualExceptionThrown = catchThrowable(() -> groupRepository.save(givenGroup));
+
+        // then
+        then(actualExceptionThrown)
+                .as("컬럼 제약 조건 위반: ")
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    static Stream<Arguments> columnConstraintViolationProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "이름 없음",
+                        Group.builder()
+                        .description("description")
+                        .build()
+                ), Arguments.of(
+                        "이름 길이 초과",
+                        Group.builder()
+                        .name("this is a group name with length violation")
+                        .description("description")
+                        .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("tableConstraintViolationProvider")
+    void constraintViolation(String description, Group givenGroup, Group givenGroupWithSameName) {
+        // when
+        groupRepository.save(givenGroup);
+        Throwable actualExceptionThrown = catchThrowable(() -> groupRepository.save(givenGroupWithSameName));
+
+        // then
+        then(actualExceptionThrown)
+                .as("테이블 제약 조건 위반: ")
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    static Stream<Arguments> tableConstraintViolationProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "이름 중복",
+                        Group.builder()
+                             .name("name")
+                             .description("")
+                             .build(),
+                        Group.builder()
+                             .name("name")
+                             .description("")
+                             .build()
+                )
+        );
+    }
 }

--- a/src/test/java/com/postsquad/scoup/web/group/repository/GroupRepositoryTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/repository/GroupRepositoryTest.java
@@ -1,0 +1,2 @@
+package com.postsquad.scoup.web.group.repository;public class GroupRepositoryTest {
+}


### PR DESCRIPTION
그룹 생성 기능 구현했습니다.
그룹에는 그룹 생성 시 필요한 `name`, `description`만 담도록 하였고 `GroupCreationRequest`를 받아 매퍼를 통해 그룹으로 변환, 저장하도록 구현하였습니다.

인수 테스트에는 정상 작동과 `GroupCreationRequest`의 유효성 검사를 테스트하였고 레포지토리 테스트에는 DB 제약조건을 테스트했습니다.

감사합니다.