### PR TITLE
[새리][3-1-2] 그룹 이름 중복 시 그룹 생성 실패

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -1,6 +1,8 @@
 package com.postsquad.scoup.web.group.controller;
 
+import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.exception.GroupCreationFailedException;
 import com.postsquad.scoup.web.group.service.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,5 +21,11 @@ public class GroupController {
     @ResponseStatus(HttpStatus.CREATED)
     public Long create(@RequestBody @Valid GroupCreationRequest groupCreationRequest) {
         return groupService.create(groupCreationRequest);
+    }
+
+    @ExceptionHandler(GroupCreationFailedException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse groupCreationFailedExceptionHandler(GroupCreationFailedException groupCreationFailedException) {
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, groupCreationFailedException.getMessage(), groupCreationFailedException.getDescription());
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/exception/GroupCreationFailedException.java
+++ b/src/main/java/com/postsquad/scoup/web/group/exception/GroupCreationFailedException.java
@@ -1,0 +1,2 @@
+package com.postsquad.scoup.web.group.exception;public class GroupCreationFailedException {
+}

--- a/src/main/java/com/postsquad/scoup/web/group/exception/GroupCreationFailedException.java
+++ b/src/main/java/com/postsquad/scoup/web/group/exception/GroupCreationFailedException.java
@@ -1,2 +1,25 @@
-package com.postsquad.scoup.web.group.exception;public class GroupCreationFailedException {
+package com.postsquad.scoup.web.group.exception;
+
+public class GroupCreationFailedException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "Failed to create group";
+    private String description;
+
+    public GroupCreationFailedException(String message) {
+        super(DEFAULT_MESSAGE);
+        description = message;
+    }
+
+    public GroupCreationFailedException(Throwable cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GroupCreationFailedException(String message, Throwable cause) {
+        super(DEFAULT_MESSAGE, cause);
+        description = message;
+    }
+
+    public String getDescription() {
+        return description;
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/exception/GroupNameAlreadyExistException.java
+++ b/src/main/java/com/postsquad/scoup/web/group/exception/GroupNameAlreadyExistException.java
@@ -1,2 +1,8 @@
-package com.postsquad.scoup.web.group.exception;public class GroupNameAlreadyExistException {
+package com.postsquad.scoup.web.group.exception;
+
+public class GroupNameAlreadyExistException extends GroupCreationFailedException {
+
+    public GroupNameAlreadyExistException(String name) {
+        super("Group name '" + name + "' already exists");
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/exception/GroupNameAlreadyExistException.java
+++ b/src/main/java/com/postsquad/scoup/web/group/exception/GroupNameAlreadyExistException.java
@@ -1,0 +1,2 @@
+package com.postsquad.scoup.web.group.exception;public class GroupNameAlreadyExistException {
+}

--- a/src/main/java/com/postsquad/scoup/web/group/repository/GroupRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/group/repository/GroupRepository.java
@@ -4,4 +4,6 @@ import com.postsquad.scoup.web.group.domain.Group;
 import org.springframework.data.repository.CrudRepository;
 
 public interface GroupRepository extends CrudRepository<Group, Long> {
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -2,6 +2,7 @@ package com.postsquad.scoup.web.group.service;
 
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
+import com.postsquad.scoup.web.group.exception.GroupNameAlreadyExistException;
 import com.postsquad.scoup.web.group.mapper.GroupMapper;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,11 @@ public class GroupService {
     private final GroupRepository groupRepository;
 
     public Long create(GroupCreationRequest groupCreationRequest) {
+
+        if (groupRepository.existsByName(groupCreationRequest.getName())) {
+            throw new GroupNameAlreadyExistException(groupCreationRequest.getName());
+        }
+
         Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest);
 
         return groupRepository.save(group).getId();

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -9,6 +9,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -16,6 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Stream;
 
@@ -25,6 +27,14 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     @Autowired
     GroupRepository groupRepository;
+
+    @BeforeEach
+    void setUp() {
+        groupRepository.save(Group.builder()
+                                  .name("name")
+                                  .description("description")
+                                  .build());
+    }
 
     @ParameterizedTest
     @MethodSource("createGroupProvider")
@@ -67,6 +77,52 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                              .name("name")
                              .description("description")
                              .build()
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("createGroupWithExistingNameProvider")
+    @DisplayName("중복된 그룹 이름이 있으면 그룹 생성을 할 수 없다.")
+    void createGroupWithExistingName(String description, GroupCreationRequest givenGroupCreationRequest, ErrorResponse expectedResponse) {
+        // given
+        String path = "/api/groups";
+        RequestSpecification givenRequest = RestAssured.given()
+                                                       .baseUri(BASE_URL)
+                                                       .port(port)
+                                                       .basePath(path)
+                                                       .contentType(ContentType.JSON)
+                                                       .header("Accept-Language", "en-US")
+                                                       .body(givenGroupCreationRequest);
+
+        // when
+        Response actualResponse = givenRequest.when()
+                                              .log().all()
+                                              .post();
+
+        actualResponse.then()
+                      .log().all()
+                      .statusCode(HttpStatus.BAD_REQUEST.value());
+        then(actualResponse.as(ErrorResponse.class))
+                .as("그룹 생성: %s", description)
+                .usingRecursiveComparison()
+                .ignoringFields(ignoringFieldsForErrorResponse)
+                .isEqualTo(expectedResponse);
+    }
+
+    static Stream<Arguments> createGroupWithExistingNameProvider() {
+        return Stream.of(
+                Arguments.of(
+                        "실패 - 이미 존재하는 그룹 이름",
+                        GroupCreationRequest.builder()
+                        .name("name")
+                        .description("description")
+                        .build(),
+                        ErrorResponse.builder()
+                        .message("Failed to create group.")
+                        .statusCode(400)
+                        .errors(Arrays.asList("Group name 'name' already exists."))
+                        .build()
                 )
         );
     }


### PR DESCRIPTION
중복된 그룹 이름이 있는 지 체크하고 있으면 예외를 던지는 로직을 구현했습니다.
예외 부분은 앞서 프레디와 제인께서 해주신 거 참고하고 처리했습니다.

감사합니다 ☺️