### PR TITLE
[Jane][1-1-2] 소셜 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/auth/OAuthType.java
+++ b/src/main/java/com/postsquad/scoup/web/auth/OAuthType.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.auth;
 
 public enum OAuthType {
+    NONE,
     GITHUB,
     KAKAO,
     GOOGLE

--- a/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.postsquad.scoup.web.user.controller.request;
 
+import com.postsquad.scoup.web.auth.OAuthType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,10 @@ import javax.validation.constraints.NotEmpty;
 @Builder
 @Data
 public class SignUpRequest {
+
+    private OAuthType oAuthType;
+
+    private String socialServiceId;
 
     @NotEmpty
     private String nickname;

--- a/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
@@ -15,8 +15,10 @@ import javax.validation.constraints.NotEmpty;
 @Data
 public class SignUpRequest {
 
+    @NotEmpty
     private OAuthType oAuthType;
 
+    @NotEmpty
     private String socialServiceId;
 
     @NotEmpty

--- a/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/request/SignUpRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,10 +16,10 @@ import javax.validation.constraints.NotEmpty;
 @Data
 public class SignUpRequest {
 
-    @NotEmpty
+    @NotNull
     private OAuthType oAuthType;
 
-    @NotEmpty
+    @NotNull
     private String socialServiceId;
 
     @NotEmpty

--- a/src/main/java/com/postsquad/scoup/web/user/domain/OAuthInfo.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/OAuthInfo.java
@@ -1,0 +1,20 @@
+package com.postsquad.scoup.web.user.domain;
+
+import com.postsquad.scoup.web.auth.OAuthType;
+import lombok.*;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Embeddable
+public class OAuthInfo {
+
+    @Enumerated(EnumType.STRING)
+    private OAuthType oAuthType;
+
+    private String socialServiceId;
+}

--- a/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
@@ -8,7 +8,6 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
 @Embeddable
 public class OAuthUser {
@@ -17,4 +16,14 @@ public class OAuthUser {
     private OAuthType oAuthType;
 
     private String socialServiceId;
+
+    protected OAuthUser(OAuthType oAuthType, String socialServiceId) {
+        this.oAuthType = oAuthType;
+        this.socialServiceId = socialServiceId;
+    }
+
+    @Builder
+    public static OAuthUser of(OAuthType oAuthType, String socialServiceId) {
+        return new OAuthUser(oAuthType, socialServiceId);
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
@@ -3,6 +3,7 @@ package com.postsquad.scoup.web.user.domain;
 import com.postsquad.scoup.web.auth.OAuthType;
 import lombok.*;
 
+import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -12,6 +13,7 @@ import javax.persistence.Enumerated;
 @Embeddable
 public class OAuthUser {
 
+    @Column(name = "oauth_type")
     @Enumerated(EnumType.STRING)
     private OAuthType oAuthType;
 

--- a/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
@@ -11,7 +11,7 @@ import javax.persistence.Enumerated;
 @AllArgsConstructor
 @Getter
 @Embeddable
-public class OAuthInfo {
+public class OAuthUser {
 
     @Enumerated(EnumType.STRING)
     private OAuthType oAuthType;

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -44,9 +44,7 @@ public class User extends BaseEntity {
         this.email = email;
         this.avatarUrl = avatarUrl;
         this.password = password;
-        if (oAuthInfoList != null) {
-            this.oAuthInfoList = oAuthInfoList;
-        }
+        this.oAuthInfoList = oAuthInfoList;
     }
 
     @Builder

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -36,19 +36,19 @@ public class User extends BaseEntity {
     @ElementCollection(fetch = FetchType.EAGER)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
-    private List<OAuthInfo> oAuthInfoList = new ArrayList<>();
+    private List<OAuthUser> oAuthUsers = new ArrayList<>();
 
-    protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfoList) {
+    protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthUser> oAuthUsers) {
         this.nickname = nickname;
         this.username = username;
         this.email = email;
         this.avatarUrl = avatarUrl;
         this.password = password;
-        this.oAuthInfoList = oAuthInfoList;
+        this.oAuthUsers = oAuthUsers;
     }
 
     @Builder
-    public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfoList) {
-        return new User(nickname, username, email, avatarUrl, password, oAuthInfoList);
+    public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthUser> oAuthUsers) {
+        return new User(nickname, username, email, avatarUrl, password, oAuthUsers);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -34,8 +34,6 @@ public class User extends BaseEntity {
     private String password;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @OnDelete(action = OnDeleteAction.CASCADE)
-    @JoinColumn(name = "user_id")
     private List<OAuthUser> oAuthUsers = new ArrayList<>();
 
     protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthUser> oAuthUsers) {

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -36,21 +36,21 @@ public class User extends BaseEntity {
     @ElementCollection(fetch = FetchType.EAGER)
     @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "user_id")
-    private List<OAuthInfo> oAuthInfo = new ArrayList<>();
+    private List<OAuthInfo> oAuthInfoList = new ArrayList<>();
 
-    protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfo) {
+    protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfoList) {
         this.nickname = nickname;
         this.username = username;
         this.email = email;
         this.avatarUrl = avatarUrl;
         this.password = password;
-        if (oAuthInfo != null) {
-            this.oAuthInfo = oAuthInfo;
+        if (oAuthInfoList != null) {
+            this.oAuthInfoList = oAuthInfoList;
         }
     }
 
     @Builder
-    public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfo) {
-        return new User(nickname, username, email, avatarUrl, password, oAuthInfo);
+    public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfoList) {
+        return new User(nickname, username, email, avatarUrl, password, oAuthInfoList);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -1,15 +1,13 @@
 package com.postsquad.scoup.web.user.domain;
 
 import com.postsquad.scoup.web.common.BaseEntity;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.UniqueConstraint;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -35,16 +33,24 @@ public class User extends BaseEntity {
     @Column(length = 30, nullable = false)
     private String password;
 
-    protected User(String nickname, String username, String email, String avatarUrl, String password) {
+    @ElementCollection(fetch = FetchType.EAGER)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "user_id")
+    private List<OAuthInfo> oAuthInfo = new ArrayList<>();
+
+    protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfo) {
         this.nickname = nickname;
         this.username = username;
         this.email = email;
         this.avatarUrl = avatarUrl;
         this.password = password;
+        if (oAuthInfo != null) {
+            this.oAuthInfo = oAuthInfo;
+        }
     }
 
     @Builder
-    public static User of(String nickname, String username, String email, String avatarUrl, String password) {
-        return new User(nickname, username, email, avatarUrl, password);
+    public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthInfo> oAuthInfo) {
+        return new User(nickname, username, email, avatarUrl, password, oAuthInfo);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -34,6 +34,7 @@ public class User extends BaseEntity {
     private String password;
 
     @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "oauth_user", joinColumns = @JoinColumn(name = "user_id"))
     private List<OAuthUser> oAuthUsers = new ArrayList<>();
 
     protected User(String nickname, String username, String email, String avatarUrl, String password, List<OAuthUser> oAuthUsers) {

--- a/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
@@ -17,6 +17,6 @@ public interface UserMapper {
 
     @AfterMapping
     default void addOAuthInfo(@MappingTarget User.UserBuilder userBuilder, SignUpRequest signUpRequest) {
-        userBuilder.oAuthUsers(List.of(new OAuthUser(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
+        userBuilder.oAuthUsers(List.of(OAuthUser.of(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
@@ -1,14 +1,22 @@
 package com.postsquad.scoup.web.user.mapper;
 
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
+import com.postsquad.scoup.web.user.domain.OAuthInfo;
 import com.postsquad.scoup.web.user.domain.User;
-import org.mapstruct.Mapper;
+import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
 
 @Mapper
 public interface UserMapper {
 
     UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
 
-    User signUpRequestToUser(SignUpRequest signUpRequest);
+    User map(SignUpRequest signUpRequest);
+
+    @AfterMapping
+    default void addOAuthInfo(@MappingTarget User.UserBuilder userBuilder, SignUpRequest signUpRequest) {
+        userBuilder.oAuthInfo(List.of(new OAuthInfo(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
@@ -17,6 +17,6 @@ public interface UserMapper {
 
     @AfterMapping
     default void addOAuthInfo(@MappingTarget User.UserBuilder userBuilder, SignUpRequest signUpRequest) {
-        userBuilder.oAuthInfo(List.of(new OAuthInfo(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
+        userBuilder.oAuthInfoList(List.of(new OAuthInfo(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/user/mapper/UserMapper.java
@@ -1,7 +1,7 @@
 package com.postsquad.scoup.web.user.mapper;
 
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
-import com.postsquad.scoup.web.user.domain.OAuthInfo;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
@@ -17,6 +17,6 @@ public interface UserMapper {
 
     @AfterMapping
     default void addOAuthInfo(@MappingTarget User.UserBuilder userBuilder, SignUpRequest signUpRequest) {
-        userBuilder.oAuthInfoList(List.of(new OAuthInfo(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
+        userBuilder.oAuthUsers(List.of(new OAuthUser(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
     private final UserRepository userRepository;
 
     public long signUp(SignUpRequest signUpRequest) {
-        User user = UserMapper.INSTANCE.signUpRequestToUser(signUpRequest);
+        User user = UserMapper.INSTANCE.map(signUpRequest);
 
         if (userRepository.existsByEmail(user.getEmail())) {
             throw new EmailAlreadyExistsException(user);

--- a/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jwt.SignedJWT;
 import com.postsquad.scoup.web.AcceptanceTestBase;
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.signin.controller.request.SignInRequest;
 import com.postsquad.scoup.web.signin.controller.response.SignInResponse;
@@ -100,6 +101,8 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "성공",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")
@@ -191,6 +194,8 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "성공",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")
@@ -244,6 +249,8 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "이메일 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")
@@ -260,6 +267,8 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "비밀번호 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -83,6 +83,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "성공",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")
@@ -93,6 +95,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .username("username")
                             .email("email@email")
                             .password("password")
+                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.NONE, "")))
                             .build()
                 )
         );
@@ -184,6 +187,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "실패 - 이미 가입한 이메일(email@email)",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .username("username")
                                      .nickname("nickname")
                                      .email("existing@email.com")
@@ -197,6 +202,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - 이미 가입한 닉네임(nickname)",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .username("username")
                                      .nickname("existing")
                                      .email("email2@email")
@@ -247,6 +254,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 Arguments.of(
                         "실패 - nickname 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .username("username")
                                      .email("email@email")
                                      .password("password")
@@ -259,6 +268,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - username 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .email("email@email")
                                      .password("password")
@@ -271,6 +282,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - email 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .password("password")
@@ -283,6 +296,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - password 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email@email")
@@ -295,6 +310,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - email 형식 다름",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .nickname("nickname")
                                      .username("username")
                                      .email("email")
@@ -308,6 +325,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 ), Arguments.of(
                         "실패 - 모두 없음",
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
                                      .build(),
                         ErrorResponse.builder()
                                      .message("Method argument not valid.")

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -6,7 +6,7 @@ import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
-import com.postsquad.scoup.web.user.domain.OAuthInfo;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.user.repository.UserRepository;
 import io.restassured.RestAssured;
@@ -95,7 +95,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .username("username")
                             .email("email@email")
                             .password("password")
-                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.NONE, "")))
+                            .oAuthUsers(List.of(new OAuthUser(OAuthType.NONE, "")))
                             .build()
                 )
         );
@@ -148,7 +148,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
+                            .oAuthUsers(List.of(new OAuthUser(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -95,7 +95,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .username("username")
                             .email("email@email")
                             .password("password")
-                            .oAuthUsers(List.of(new OAuthUser(OAuthType.NONE, "")))
+                            .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "")))
                             .build()
                 )
         );
@@ -148,7 +148,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthUsers(List.of(new OAuthUser(OAuthType.GITHUB, "1234567")))
+                            .oAuthUsers(List.of(OAuthUser.of(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -52,7 +52,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @ParameterizedTest
     @MethodSource("signUpProvider")
-    @DisplayName("신규 사용자는 이메일을 통해 회원가입을 할 수 있다.")
+    @DisplayName("신규 사용자는 이메일을 통해 회원가입을 할 수 있다")
     void signUp(String description, SignUpRequest givenSignUpRequest, User expectedUser) {
         // given
         String path = "/api/users";
@@ -153,7 +153,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @ParameterizedTest
     @MethodSource("signUpWhenUserAlreadyExistsProvider")
-    @DisplayName("기사용자가 회원가입을 한 경우 회원가입이 되지 않는다.")
+    @DisplayName("기사용자가 회원가입을 한 경우 회원가입이 되지 않는다")
     void signUpWhenUserAlreadyExists(String description, SignUpRequest givenSignUpRequestAlreadyExists, ErrorResponse expectedResponse) {
         // given
         String path = "/api/users";
@@ -324,7 +324,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @ParameterizedTest
     @MethodSource("validateEmailProvider")
-    @DisplayName("이미 가입된 이메일을 입력할 경우 이메일이 중복되었다는 메시지가 반환된다.")
+    @DisplayName("이미 가입된 이메일을 입력할 경우 이메일이 중복되었다는 메시지가 반환된다")
     void validateEmail(String description, String givenEmail, EmailValidationResponse expectedEmailValidationResponse) {
         // given
         String path = "/api/users/validate/email";
@@ -426,7 +426,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @ParameterizedTest
     @MethodSource("validateNicknameProvider")
-    @DisplayName("이미 가입된 닉네임을 입력할 경우 닉네임이 중복되었다는 메시지가 반환된다.")
+    @DisplayName("이미 가입된 닉네임을 입력할 경우 닉네임이 중복되었다는 메시지가 반환된다")
     void validateNickname(String description, String givenNickname, NicknameValidationResponse expectedNicknameValidationResponse) {
         // given
         String path = "/api/users/validate/nickname";

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -145,7 +145,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthInfo(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
+                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -126,7 +126,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                 .isEqualTo(expectedUser);
     }
 
-    private static Stream<Arguments> socialSignUpProvider() {
+    static Stream<Arguments> socialSignUpProvider() {
         return Stream.of(
                 Arguments.of(
                         "성공",

--- a/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
@@ -31,6 +31,23 @@ class UserMapperTest {
         return Stream.of(
                 Arguments.arguments(
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.NONE)
+                                     .socialServiceId("")
+                                     .nickname("nickname")
+                                     .username("username")
+                                     .email("email")
+                                     .password("password")
+                                     .build(),
+                        User.builder()
+                            .nickname("nickname")
+                            .username("username")
+                            .email("email")
+                            .password("password")
+                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.NONE, "")))
+                            .build()
+                ),
+                Arguments.arguments(
+                        SignUpRequest.builder()
                                      .oAuthType(OAuthType.GITHUB)
                                      .socialServiceId("1234567")
                                      .nickname("nickname")
@@ -45,7 +62,7 @@ class UserMapperTest {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthInfo(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
+                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
@@ -1,11 +1,14 @@
 package com.postsquad.scoup.web.user.mapper;
 
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
+import com.postsquad.scoup.web.user.domain.OAuthInfo;
 import com.postsquad.scoup.web.user.domain.User;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.BDDAssertions.then;
@@ -28,16 +31,21 @@ class UserMapperTest {
         return Stream.of(
                 Arguments.arguments(
                         SignUpRequest.builder()
+                                     .oAuthType(OAuthType.GITHUB)
+                                     .socialServiceId("1234567")
                                      .nickname("nickname")
                                      .username("username")
-                                     .email("email")
+                                     .email("email@email")
                                      .password("password")
+                                     .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
                                      .build(),
                         User.builder()
                             .nickname("nickname")
                             .username("username")
-                            .email("email")
+                            .email("email@email")
                             .password("password")
+                            .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
+                            .oAuthInfo(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
@@ -16,7 +16,7 @@ class UserMapperTest {
     @MethodSource("signUpRequestToUserProvider")
     void signUpRequestToUser(SignUpRequest givenSignUpRequest, User expectedUser) {
         //when
-        User actualUser = UserMapper.INSTANCE.signUpRequestToUser(givenSignUpRequest);
+        User actualUser = UserMapper.INSTANCE.map(givenSignUpRequest);
 
         //then
         then(actualUser).usingRecursiveComparison()

--- a/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
@@ -43,7 +43,7 @@ class UserMapperTest {
                             .username("username")
                             .email("email")
                             .password("password")
-                            .oAuthUsers(List.of(new OAuthUser(OAuthType.NONE, "")))
+                            .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "")))
                             .build()
                 ),
                 Arguments.arguments(
@@ -62,7 +62,7 @@ class UserMapperTest {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthUsers(List.of(new OAuthUser(OAuthType.GITHUB, "1234567")))
+                            .oAuthUsers(List.of(OAuthUser.of(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/mapper/UserMapperTest.java
@@ -2,7 +2,7 @@ package com.postsquad.scoup.web.user.mapper;
 
 import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
-import com.postsquad.scoup.web.user.domain.OAuthInfo;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -43,7 +43,7 @@ class UserMapperTest {
                             .username("username")
                             .email("email")
                             .password("password")
-                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.NONE, "")))
+                            .oAuthUsers(List.of(new OAuthUser(OAuthType.NONE, "")))
                             .build()
                 ),
                 Arguments.arguments(
@@ -62,7 +62,7 @@ class UserMapperTest {
                             .email("email@email")
                             .password("password")
                             .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                            .oAuthInfoList(List.of(new OAuthInfo(OAuthType.GITHUB, "1234567")))
+                            .oAuthUsers(List.of(new OAuthUser(OAuthType.GITHUB, "1234567")))
                             .build()
                 )
         );


### PR DESCRIPTION
OAuthInfo 리스트 추가 후 테스트에서 deleteAll() 메서드 실행 시 발생하는 `ConstraintViolationException`을 해결하다가 기능 구현에 비해 시간이 오래 걸렸네요ㅎㅎ

덤으로 UserMapper에 `@AfterMapping`을 이용한 커스텀 메서드를 추가할 때 빌더를 파라미터로 받아야 한다고 합니다. 이것도 한 삽질했어요😂
```java
    @AfterMapping
    default void addOAuthInfo(@MappingTarget User.UserBuilder userBuilder, SignUpRequest signUpRequest) {
        userBuilder.oAuthInfo(List.of(new OAuthInfo(signUpRequest.getOAuthType(), signUpRequest.getSocialServiceId())));
    }
```
새리의 코멘트를 보고 찾아보니 정확히는 `@AfterMapping`이 아닌 `@MappingTarget`이 문제였네요. `@MapingTarget`에 업데이트하고 싶은 객체를 지정할 수 있는데 객체에 맵핑된 빌더가 있을 경우 빌더가 맵핑에 사용되어 빌더를 받아줘야 하는 거였어요.

> MapStruct also supports mapping of immutable types via builders. When performing a mapping MapStruct checks if there is a builder for the type being mapped. This is done via the BuilderProvider SPI. If a Builder exists for a certain type, then that builder will be used for the mappings.
