### PR TITLE
[Jane][1-1-3] 이미 가입한 소셜 서비스로는 중복 가입을 못하도록 방지하는 기능 구현

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/OAuthUser.java
@@ -3,13 +3,14 @@ package com.postsquad.scoup.web.user.domain;
 import com.postsquad.scoup.web.auth.OAuthType;
 import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
+import javax.persistence.*;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"oauth_type"}, name = "UK_OAUTH_TYPE"),
+        @UniqueConstraint(columnNames = {"social_service_id"}, name = "UK_SOCIAL_SERVICE_ID"),
+})
 @Embeddable
 public class OAuthUser {
 
@@ -27,5 +28,9 @@ public class OAuthUser {
     @Builder
     public static OAuthUser of(OAuthType oAuthType, String socialServiceId) {
         return new OAuthUser(oAuthType, socialServiceId);
+    }
+
+    public String getOAuthTypeName() {
+        return oAuthType.name();
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -3,8 +3,6 @@ package com.postsquad.scoup.web.user.domain;
 import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.common.BaseEntity;
 import lombok.*;
-import org.hibernate.annotations.OnDelete;
-import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -58,5 +56,9 @@ public class User extends BaseEntity {
 
     public OAuthType getFirstRegisteredOAuthType() {
         return this.oAuthUsers.get(0).getOAuthType();
+    }
+
+    public boolean isOAuthUser() {
+        return getFirstRegisteredOAuthType() != OAuthType.NONE;
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/domain/User.java
+++ b/src/main/java/com/postsquad/scoup/web/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.postsquad.scoup.web.user.domain;
 
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.common.BaseEntity;
 import lombok.*;
 import org.hibernate.annotations.OnDelete;
@@ -49,5 +50,13 @@ public class User extends BaseEntity {
     @Builder
     public static User of(String nickname, String username, String email, String avatarUrl, String password, List<OAuthUser> oAuthUsers) {
         return new User(nickname, username, email, avatarUrl, password, oAuthUsers);
+    }
+
+    public OAuthUser getFirstRegisteredOAuthUser() {
+        return this.oAuthUsers.get(0);
+    }
+
+    public OAuthType getFirstRegisteredOAuthType() {
+        return this.oAuthUsers.get(0).getOAuthType();
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
@@ -18,6 +18,11 @@ public interface UserRepository extends CrudRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
-    @Query("select case when count(u)>0 then true else false end from User u where :oAuthUser member of u.oAuthUsers")
-    boolean existsByOAuthUser(@Param("oAuthUser") OAuthUser oAuthUser);
+    @Query(value = "select count(*) from \"oauth_user\" where \"oauth_type\"=:oAuthType and \"social_service_id\"=:socialServiceId",
+           nativeQuery = true)
+    long existsByOAuthUser(@Param("oAuthType") String oAuthType, @Param("socialServiceId") String socialServiceId);
+
+    default boolean existsByOAuthUser(OAuthUser oAuthUser) {
+        return existsByOAuthUser(oAuthUser.getOAuthTypeName(), oAuthUser.getSocialServiceId()) > 0;
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
@@ -1,7 +1,10 @@
 package com.postsquad.scoup.web.user.repository;
 
+import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,4 +17,7 @@ public interface UserRepository extends CrudRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    @Query("select case when count(u)>0 then true else false end from User u where :oAuthUser member of u.oAuthUsers")
+    boolean existsByOAuthUser(@Param("oAuthUser") OAuthUser oAuthUser);
 }

--- a/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/user/repository/UserRepository.java
@@ -20,9 +20,9 @@ public interface UserRepository extends CrudRepository<User, Long> {
 
     @Query(value = "select count(*) from \"oauth_user\" where \"oauth_type\"=:oAuthType and \"social_service_id\"=:socialServiceId",
            nativeQuery = true)
-    long existsByOAuthUser(@Param("oAuthType") String oAuthType, @Param("socialServiceId") String socialServiceId);
+    long countOAuthUSer(@Param("oAuthType") String oAuthType, @Param("socialServiceId") String socialServiceId);
 
     default boolean existsByOAuthUser(OAuthUser oAuthUser) {
-        return existsByOAuthUser(oAuthUser.getOAuthTypeName(), oAuthUser.getSocialServiceId()) > 0;
+        return countOAuthUSer(oAuthUser.getOAuthTypeName(), oAuthUser.getSocialServiceId()) > 0;
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/service/OAuthUserAlreadyExistsException.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/OAuthUserAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.postsquad.scoup.web.user.service;
+
+import com.postsquad.scoup.web.user.domain.User;
+
+public class OAuthUserAlreadyExistsException extends UserAlreadyExistsException {
+    public OAuthUserAlreadyExistsException(User user) {
+        super(user.getFirstRegisteredOAuthType() + " account already exists");
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -19,7 +19,7 @@ public class UserService {
     public long signUp(SignUpRequest signUpRequest) {
         User user = UserMapper.INSTANCE.map(signUpRequest);
 
-        if (user.getFirstRegisteredOAuthType() != OAuthType.NONE && userRepository.existsByOAuthUser(user.getFirstRegisteredOAuthUser())) {
+        if (user.isOAuthUser() && userRepository.existsByOAuthUser(user.getFirstRegisteredOAuthUser())) {
             throw new OAuthUserAlreadyExistsException(user);
         }
 

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.postsquad.scoup.web.user.service;
 
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -17,6 +18,10 @@ public class UserService {
 
     public long signUp(SignUpRequest signUpRequest) {
         User user = UserMapper.INSTANCE.map(signUpRequest);
+
+        if (user.getFirstRegisteredOAuthType() != OAuthType.NONE && userRepository.existsByOAuthUser(user.getFirstRegisteredOAuthUser())) {
+            throw new OAuthUserAlreadyExistsException(user);
+        }
 
         if (userRepository.existsByEmail(user.getEmail())) {
             throw new EmailAlreadyExistsException(user);

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -1,6 +1,5 @@
 package com.postsquad.scoup.web.user.service;
 
-import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -38,16 +38,6 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                                 .avatarUrl("avatarUrl")
                                 .password("password")
                                 .build());
-        if (testInfo.getTags().contains("social-sign-up-fail")) {
-            userRepository.save(User.builder()
-                                    .nickname("nickname")
-                                    .username("username")
-                                    .email("email@email.com")
-                                    .avatarUrl("avatarUrl")
-                                    .password("password")
-                                    .oAuthUsers(List.of(OAuthUser.of(OAuthType.GITHUB, "1234567")))
-                                    .build());
-        }
     }
 
     @AfterEach
@@ -103,9 +93,16 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @ParameterizedTest
     @ArgumentsSource(SignUpViaSocialWhenUserAlreadyExistsProvider.class)
-    @Tag("social-sign-up-fail")
     @DisplayName("기사용자가 회원가입을 한 경우 회원가입이 되지 않는다 - 소셜")
     void signUpViaSocialWhenUserAlreadyExists(String description, SignUpRequest givenSignUpRequestAlreadyExists, ErrorResponse expectedResponse) {
+        userRepository.save(User.builder()
+                                .nickname("nickname")
+                                .username("username")
+                                .email("email@email.com")
+                                .avatarUrl("avatarUrl")
+                                .password("password")
+                                .oAuthUsers(List.of(OAuthUser.of(OAuthType.GITHUB, "1234567")))
+                                .build());
         signUpWhenUserAlreadyExists(description, givenSignUpRequestAlreadyExists, expectedResponse);
     }
 

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -58,35 +58,18 @@ class UserAcceptanceTest extends AcceptanceTestBase {
     @ParameterizedTest
     @ArgumentsSource(EmailSignUpProvider.class)
     @DisplayName("신규 사용자는 이메일을 통해 회원가입을 할 수 있다")
-    void emailSignUp(String description, SignUpRequest givenEmailSignUpRequest, User expectedUser) {
-        // given
-        String path = "/api/users";
-        RequestSpecification givenRequest = RestAssured.given()
-                                                       .baseUri(BASE_URL)
-                                                       .port(port)
-                                                       .basePath(path)
-                                                       .contentType(ContentType.JSON)
-                                                       .body(givenEmailSignUpRequest);
-
-        // when
-        Response actualResponse = givenRequest.when()
-                                              .log().all(true)
-                                              .post();
-
-        // then
-        actualResponse.then()
-                      .statusCode(HttpStatus.CREATED.value());
-        then(userRepository.findById(actualResponse.body().as(long.class)).orElse(null))
-                .as("회원가입 결과 : %s", description)
-                .usingRecursiveComparison()
-                .ignoringFields(ignoringFieldsForResponseWithId)
-                .isEqualTo(expectedUser);
+    void emailSignUp(String description, SignUpRequest givenSignUpRequest, User expectedUser) {
+        signUp(description, givenSignUpRequest, expectedUser);
     }
 
     @ParameterizedTest
     @ArgumentsSource(SocialSignUpProvider.class)
     @DisplayName("신규 사용자는 소셜 서비스를 통해 회원가입을 할 수 있다")
-    void socialSignUp(String description, SignUpRequest givenSocialSignUpRequest, User expectedUser) {
+    void socialSignUp(String description, SignUpRequest givenSignUpRequest, User expectedUser) {
+        signUp(description, givenSignUpRequest, expectedUser);
+    }
+
+    private void signUp(String description, SignUpRequest givenSocialSignUpRequest, User expectedUser) {
         // given
         String path = "/api/users";
         RequestSpecification givenRequest = RestAssured.given()

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -30,7 +30,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
     UserRepository userRepository;
 
     @BeforeEach
-    void setUp(TestInfo testInfo) {
+    void setUp() {
         userRepository.save(User.builder()
                                 .nickname("existing")
                                 .username("username")

--- a/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaEmailWhenUserAlreadyExistsProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaEmailWhenUserAlreadyExistsProvider.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
-public class SignUpWhenUserAlreadyExistsProvider implements ArgumentsProvider {
+public class SignUpViaEmailWhenUserAlreadyExistsProvider implements ArgumentsProvider {
 
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {

--- a/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaSocialWhenUserAlreadyExistsProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaSocialWhenUserAlreadyExistsProvider.java
@@ -1,0 +1,35 @@
+package com.postsquad.scoup.web.user.provider;
+
+import com.postsquad.scoup.web.auth.OAuthType;
+import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class SignUpViaSocialWhenUserAlreadyExistsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(
+                        "실패 - 이미 가입한 소셜 서비스",
+                        SignUpRequest.builder()
+                                     .oAuthType(OAuthType.GITHUB)
+                                     .socialServiceId("1234567")
+                                     .username("username")
+                                     .nickname("existing")
+                                     .email("email2@email")
+                                     .password("password")
+                                     .build(),
+                        ErrorResponse.builder()
+                                     .message("Sign up failed")
+                                     .statusCode(400)
+                                     .errors(List.of("GITHUB account already exists"))
+                                     .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaSocialWhenUserAlreadyExistsProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/user/provider/SignUpViaSocialWhenUserAlreadyExistsProvider.java
@@ -20,7 +20,7 @@ public class SignUpViaSocialWhenUserAlreadyExistsProvider implements ArgumentsPr
                                      .oAuthType(OAuthType.GITHUB)
                                      .socialServiceId("1234567")
                                      .username("username")
-                                     .nickname("existing")
+                                     .nickname("nickname2")
                                      .email("email2@email")
                                      .password("password")
                                      .build(),


### PR DESCRIPTION
이미 가입한 소셜 서비스로는 재가입을 못하도록 방지하는 기능을 구현했습니다.

일단은 querydsl을 사용하지 않아 아래와 같이 처리했습니다.
```java
    @Query("select case when count(u)>0 then true else false end from User u where :oAuthUser member of u.oAuthUsers")
    boolean existsByOAuthUser(@Param("oAuthUser") OAuthUser oAuthUser);
```

그리고 테스트 setup 시 발생하는 uk 유일성 문제를 해결하기 위해 tag로 테스트를 식별하였는데 더 좋은 방법이 있다면 의견 부탁드립니다.