### PR TITLE
[새리][3-2-1] 그룹 수정

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -1,16 +1,20 @@
 package com.postsquad.scoup.web.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postsquad.scoup.web.user.UserArgumentResolver;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import reactor.netty.http.client.HttpClient;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -27,5 +31,10 @@ public class WebConfig implements WebMvcConfigurer {
                                                                   .codecs(configurer -> configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(baseConfig)))
                                                                   .build();
         return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).exchangeStrategies(exchangeStrategies).build();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserArgumentResolver());
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -3,7 +3,7 @@ package com.postsquad.scoup.web.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
-import io.netty.resolver.DefaultAddressResolverGroup;:
+import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -1,8 +1,9 @@
 package com.postsquad.scoup.web.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
-import io.netty.resolver.DefaultAddressResolverGroup;
+import io.netty.resolver.DefaultAddressResolverGroup;:
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +12,7 @@ import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import reactor.netty.http.client.HttpClient;
 
@@ -19,6 +21,10 @@ import java.util.List;
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private static final String[] PATH_TO_EXCLUDE = {"/sign-in/**", "/oauth/**", "/users/**", "/h2-console/**"};
+
+    private final SignInInterceptor signInInterceptor;
 
     @Bean
     public HttpClient httpClient() {
@@ -36,5 +42,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserArgumentResolver());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(signInInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(PATH_TO_EXCLUDE);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -5,8 +5,10 @@ import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -18,11 +20,13 @@ import reactor.netty.http.client.HttpClient;
 
 import java.util.List;
 
+@PropertySource("classpath:sign-in.properties")
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private static final String[] PATH_TO_EXCLUDE = {"/sign-in/**", "/oauth/**", "/users/**", "/h2-console/**"};
+    @Value("${sign-in.interceptor.path-to-exclude}")
+    private final String[] PATH_TO_EXCLUDE;
 
     private final SignInInterceptor signInInterceptor;
 

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     @Value("${sign-in.interceptor.path-to-exclude}")
-    private final String[] PATH_TO_EXCLUDE;
+    private final String[] SIGNIN_PATH_TO_EXCLUDE;
 
     private final SignInInterceptor signInInterceptor;
 
@@ -52,6 +52,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(signInInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns(PATH_TO_EXCLUDE);
+                .excludePathPatterns(SIGNIN_PATH_TO_EXCLUDE);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -5,10 +5,8 @@ import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
 import io.netty.resolver.DefaultAddressResolverGroup;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -20,13 +18,11 @@ import reactor.netty.http.client.HttpClient;
 
 import java.util.List;
 
-@PropertySource("classpath:sign-in.properties")
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Value("${sign-in.interceptor.path-to-exclude}")
-    private final String[] SIGNIN_PATH_TO_EXCLUDE;
+    private final String[] SIGNIN_PATH_TO_EXCLUDE = {"/sign-in/**", "/users/**", "/oauth/**", "/h2-console/**"};
 
     private final SignInInterceptor signInInterceptor;
 

--- a/src/main/java/com/postsquad/scoup/web/error/controller/ErrorControllerAdvice.java
+++ b/src/main/java/com/postsquad/scoup/web/error/controller/ErrorControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.error.controller;
 
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.signin.exception.AuthorizationFailedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -24,5 +25,11 @@ public class ErrorControllerAdvice {
     public ErrorResponse constraintViolationExceptionHandler(ConstraintViolationException constraintViolationException) {
         String message = "Method argument not valid.";
         return ErrorResponse.of(HttpStatus.BAD_REQUEST, message, constraintViolationException.getConstraintViolations());
+    }
+
+    @ExceptionHandler(AuthorizationFailedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse authenticationFailedExceptionHandler(AuthorizationFailedException authorizationFailedException) {
+        return ErrorResponse.of(HttpStatus.UNAUTHORIZED, authorizationFailedException.getMessage(), authorizationFailedException.description());
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -4,6 +4,8 @@ import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.exception.GroupCreationFailedException;
 import com.postsquad.scoup.web.group.service.GroupService;
+import com.postsquad.scoup.web.user.LoggedInUser;
+import com.postsquad.scoup.web.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -19,8 +21,8 @@ public class GroupController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public Long create(@RequestBody @Valid GroupCreationRequest groupCreationRequest) {
-        return groupService.create(groupCreationRequest);
+    public Long create(@RequestBody @Valid GroupCreationRequest groupCreationRequest, @LoggedInUser User user) {
+        return groupService.create(groupCreationRequest, user);
     }
 
     @ExceptionHandler(GroupCreationFailedException.class)

--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package com.postsquad.scoup.web.group.controller;
 
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
 import com.postsquad.scoup.web.group.exception.GroupCreationFailedException;
 import com.postsquad.scoup.web.group.service.GroupService;
 import com.postsquad.scoup.web.user.LoggedInUser;
@@ -29,5 +30,11 @@ public class GroupController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse groupCreationFailedExceptionHandler(GroupCreationFailedException groupCreationFailedException) {
         return ErrorResponse.of(HttpStatus.BAD_REQUEST, groupCreationFailedException.getMessage(), groupCreationFailedException.getDescription());
+    }
+
+    @PutMapping("/{groupId}")
+    @ResponseStatus(HttpStatus.OK)
+    public Long update(@PathVariable Long groupId, @RequestBody @Valid GroupModificationRequest groupModificationRequest, @LoggedInUser User user) {
+        return groupService.update(groupId, groupModificationRequest, user);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupModificationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/request/GroupModificationRequest.java
@@ -1,7 +1,16 @@
 package com.postsquad.scoup.web.group.controller.request;
 
-import lombok.Getter;
+import lombok.*;
 
-@Getter
+import javax.validation.constraints.NotEmpty;
+
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+@Data
 public class GroupModificationRequest extends GroupBaseRequest {
+
+    @Builder
+    public GroupModificationRequest(@NotEmpty String name, String description) {
+        super(name, description);
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -44,4 +44,8 @@ public class Group extends BaseEntity {
         this.description = groupModificationRequest.getDescription();
         return this;
     }
+
+    public boolean verifyOwner(User user) {
+        return this.owner.equals(user);
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.group.domain;
 
 import com.postsquad.scoup.web.common.BaseEntity;
+import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
 import com.postsquad.scoup.web.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -36,5 +37,11 @@ public class Group extends BaseEntity {
     @Builder
     public static Group of(String name, String description, User owner) {
         return new Group(name, description, owner);
+    }
+
+    public Group update(GroupModificationRequest groupModificationRequest) {
+        this.name = groupModificationRequest.getName();
+        this.description = groupModificationRequest.getDescription();
+        return this;
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
+++ b/src/main/java/com/postsquad/scoup/web/group/domain/Group.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.group.domain;
 
 import com.postsquad.scoup.web.common.BaseEntity;
+import com.postsquad.scoup.web.user.domain.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,13 +23,18 @@ public class Group extends BaseEntity {
     @Column(length = 200)
     private String description;
 
-    protected Group(String name, String description) {
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User owner;
+
+    protected Group(String name, String description, User owner) {
         this.name = name;
         this.description = description;
+        this.owner = owner;
     }
 
     @Builder
-    public static Group of(String name, String description) {
-        return new Group(name, description);
+    public static Group of(String name, String description, User owner) {
+        return new Group(name, description, owner);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/exception/GroupNotFoundException.java
+++ b/src/main/java/com/postsquad/scoup/web/group/exception/GroupNotFoundException.java
@@ -1,0 +1,8 @@
+package com.postsquad.scoup.web.group.exception;
+
+public class GroupNotFoundException extends RuntimeException {
+
+    public GroupNotFoundException(Long groupId) {
+        super("Group with id '" + groupId + "' does not exist");
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
@@ -13,5 +13,5 @@ public interface GroupMapper {
     GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
 
     @Mapping(target = "owner", source = "owner")
-    Group groupCreationRequestToGroup(GroupCreationRequest groupCreationRequest, User owner);
+    Group map(GroupCreationRequest groupCreationRequest, User owner);
 }

--- a/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/group/mapper/GroupMapper.java
@@ -2,7 +2,9 @@ package com.postsquad.scoup.web.group.mapper;
 
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
+import com.postsquad.scoup.web.user.domain.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -10,5 +12,6 @@ public interface GroupMapper {
 
     GroupMapper INSTANCE = Mappers.getMapper(GroupMapper.class);
 
-    Group groupCreationRequestToGroup(GroupCreationRequest groupCreationRequest);
+    @Mapping(target = "owner", source = "owner")
+    Group groupCreationRequestToGroup(GroupCreationRequest groupCreationRequest, User owner);
 }

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -24,7 +24,7 @@ public class GroupService {
             throw new GroupNameAlreadyExistException(groupCreationRequest.getName());
         }
 
-        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest, user);
+        Group group = GroupMapper.INSTANCE.map(groupCreationRequest, user);
 
         return groupRepository.save(group).getId();
     }

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -36,7 +36,7 @@ public class GroupService {
         }
 
         Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));
-        if (!group.getOwner().getId().equals(user.getId())) {
+        if (group.verifyOwner(user)) {
             throw new UnauthorizedUserException();
         }
         return groupRepository.save(group.update(groupModificationRequest)).getId();

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -1,10 +1,13 @@
 package com.postsquad.scoup.web.group.service;
 
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
 import com.postsquad.scoup.web.group.exception.GroupNameAlreadyExistException;
+import com.postsquad.scoup.web.group.exception.GroupNotFoundException;
 import com.postsquad.scoup.web.group.mapper.GroupMapper;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.signin.exception.UnauthorizedUserException;
 import com.postsquad.scoup.web.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,5 +27,18 @@ public class GroupService {
         Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest, user);
 
         return groupRepository.save(group).getId();
+    }
+
+    public Long update(Long groupId, GroupModificationRequest groupModificationRequest, User user) {
+
+        if (groupRepository.existsByName(groupModificationRequest.getName())) {
+            throw new GroupNameAlreadyExistException(groupModificationRequest.getName());
+        }
+
+        Group group = groupRepository.findById(groupId).orElseThrow(() -> new GroupNotFoundException(groupId));
+        if (!group.getOwner().getId().equals(user.getId())) {
+            throw new UnauthorizedUserException();
+        }
+        return groupRepository.save(group.update(groupModificationRequest)).getId();
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
+++ b/src/main/java/com/postsquad/scoup/web/group/service/GroupService.java
@@ -5,6 +5,7 @@ import com.postsquad.scoup.web.group.domain.Group;
 import com.postsquad.scoup.web.group.exception.GroupNameAlreadyExistException;
 import com.postsquad.scoup.web.group.mapper.GroupMapper;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,13 +15,13 @@ public class GroupService {
 
     private final GroupRepository groupRepository;
 
-    public Long create(GroupCreationRequest groupCreationRequest) {
+    public Long create(GroupCreationRequest groupCreationRequest, User user) {
 
         if (groupRepository.existsByName(groupCreationRequest.getName())) {
             throw new GroupNameAlreadyExistException(groupCreationRequest.getName());
         }
 
-        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest);
+        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(groupCreationRequest, user);
 
         return groupRepository.save(group).getId();
     }

--- a/src/main/java/com/postsquad/scoup/web/signin/controller/SignInInterceptor.java
+++ b/src/main/java/com/postsquad/scoup/web/signin/controller/SignInInterceptor.java
@@ -1,0 +1,35 @@
+package com.postsquad.scoup.web.signin.controller;
+
+import com.nimbusds.jwt.SignedJWT;
+import com.postsquad.scoup.web.signin.exception.AuthorizationFailedException;
+import com.postsquad.scoup.web.signin.exception.UserNotFoundException;
+import com.postsquad.scoup.web.user.domain.User;
+import com.postsquad.scoup.web.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@RequiredArgsConstructor
+@Component
+public class SignInInterceptor implements HandlerInterceptor {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null) {
+            throw new AuthorizationFailedException("Sign in required");
+        }
+
+        String token = authorization.substring("Bearer ".length());
+        Long userId = Long.parseLong(SignedJWT.parse(token).getJWTClaimsSet().getSubject());
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        request.setAttribute("user", user);
+
+        return true;
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/signin/exception/AuthorizationFailedException.java
+++ b/src/main/java/com/postsquad/scoup/web/signin/exception/AuthorizationFailedException.java
@@ -1,0 +1,22 @@
+package com.postsquad.scoup.web.signin.exception;
+
+public class AuthorizationFailedException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "Authorization failed";
+
+    private final String description;
+
+    public AuthorizationFailedException(String message) {
+        super(DEFAULT_MESSAGE);
+        this.description = message;
+    }
+
+    public AuthorizationFailedException(String message, Throwable cause) {
+        super(DEFAULT_MESSAGE, cause);
+        this.description = message;
+    }
+
+    public String description() {
+        return description;
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/signin/exception/UnauthorizedUserException.java
+++ b/src/main/java/com/postsquad/scoup/web/signin/exception/UnauthorizedUserException.java
@@ -1,0 +1,8 @@
+package com.postsquad.scoup.web.signin.exception;
+
+public class UnauthorizedUserException extends AuthorizationFailedException {
+
+    public UnauthorizedUserException() {
+        super("Access denied");
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/signin/exception/UserNotFoundException.java
+++ b/src/main/java/com/postsquad/scoup/web/signin/exception/UserNotFoundException.java
@@ -6,4 +6,8 @@ public class UserNotFoundException extends SignInFailedException {
     public UserNotFoundException(String email) {
         super("User '" + email + "' not exists");
     }
+
+    public UserNotFoundException(Long id) {
+        super("User with id '" + id + "' not exists");
+    }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/LoggedInUser.java
+++ b/src/main/java/com/postsquad/scoup/web/user/LoggedInUser.java
@@ -1,0 +1,11 @@
+package com.postsquad.scoup.web.user;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoggedInUser {
+}

--- a/src/main/java/com/postsquad/scoup/web/user/UserArgumentResolver.java
+++ b/src/main/java/com/postsquad/scoup/web/user/UserArgumentResolver.java
@@ -1,0 +1,27 @@
+package com.postsquad.scoup.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Component
+@RequiredArgsConstructor
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoggedInUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getAttribute("user");
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.jackson.property-naming-strategy=SNAKE_CASE
 server.servlet.context-path=/api
 
 # datasource
-spring.datasource.url=jdbc:h2:mem:testdb;MODE=MYSQL;INIT=CREATE SCHEMA IF NOT EXISTS `scoup`\\;SET SCHEMA scoup;
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL;INIT=CREATE SCHEMA IF NOT EXISTS `scoup`\\;SET SCHEMA scoup;
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=

--- a/src/main/resources/sign-in.properties
+++ b/src/main/resources/sign-in.properties
@@ -1,1 +1,0 @@
-sign-in.interceptor.path-to-exclude=/sign-in/**,/users/**,/oauth/**,/h2-console/**

--- a/src/main/resources/sign-in.properties
+++ b/src/main/resources/sign-in.properties
@@ -1,0 +1,1 @@
+sign-in.interceptor.path-to-exclude=/sign-in/**,/users/**,/oauth/**,/h2-console/**

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -6,6 +6,7 @@ import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.group.provider.CreateGroupProvider;
 import com.postsquad.scoup.web.group.provider.CreateGroupWithExistingNameProvider;
@@ -24,6 +25,8 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.ArrayList;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -44,6 +47,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                        .password("password")
                                        .avatarUrl("url")
                                        .username("username")
+                                       .oAuthUsers(new ArrayList<>())
                                        .build();
 
     @BeforeEach
@@ -95,7 +99,6 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
         then(actualGroup.getOwner())
                 .usingRecursiveComparison()
                 .ignoringFields(ignoringFieldsForResponseWithId)
-                .ignoringFields("oAuthUsers")
                 .isEqualTo(expectedGroup.getOwner());
     }
 

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -23,9 +23,11 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     @Autowired

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -1,17 +1,18 @@
 package com.postsquad.scoup.web.group;
 
 import com.postsquad.scoup.web.AcceptanceTestBase;
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
-import com.postsquad.scoup.web.group.repository.GroupRepository;
-import com.postsquad.scoup.web.user.domain.OAuthUser;
-import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.group.provider.CreateGroupProvider;
 import com.postsquad.scoup.web.group.provider.CreateGroupWithExistingNameProvider;
 import com.postsquad.scoup.web.group.provider.ModifyGroupProvider;
 import com.postsquad.scoup.web.group.provider.ValidateGroupCreationRequestProvider;
+import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
+import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -26,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -47,7 +48,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                        .password("password")
                                        .avatarUrl("url")
                                        .username("username")
-                                       .oAuthUsers(new ArrayList<>())
+                                       .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
                                        .build();
 
     @BeforeEach

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     @Autowired
@@ -42,28 +42,18 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     // temporary token with sub(userId) = 1, exp = 2023-01-01T00:00:00.000(Korean Standard Time)
     private static String TEST_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjcyNDk4ODAwfQ.DXojMeUGIq77XWvQK0luZtZhsi-c6s9qjiiu9vHhkbg";
-    public static User TEST_USER = User.builder()
-                                       .nickname("nickname")
-                                       .email("email@email.com")
-                                       .password("password")
-                                       .avatarUrl("url")
-                                       .username("username")
-                                       .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
-                                       .build();
+    private User testUser;
 
     @BeforeEach
     void setUp() {
-        TEST_USER = userRepository.save(TEST_USER);
-        groupRepository.save(Group.builder()
-                                  .name("name")
-                                  .description("description")
-                                  .owner(TEST_USER)
-                                  .build());
-    }
-
-    @AfterEach
-    void tearDown() {
-        groupRepository.deleteAll();
+        testUser = userRepository.save(User.builder()
+                                           .nickname("nickname")
+                                           .email("email@email.com")
+                                           .password("password")
+                                           .avatarUrl("url")
+                                           .username("username")
+                                           .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
+                                           .build());
     }
 
     @ParameterizedTest
@@ -108,6 +98,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
     @DisplayName("중복된 그룹 이름이 있으면 그룹 생성을 할 수 없다.")
     void createGroupWithExistingName(String description, GroupCreationRequest givenGroupCreationRequest, ErrorResponse expectedResponse) {
         // given
+        groupRepository.save(Group.builder().name("name").description("").build());
         String path = "/api/groups";
         RequestSpecification givenRequest = RestAssured.given()
                                                        .baseUri(BASE_URL)
@@ -169,6 +160,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
     @DisplayName("사용자가 그룹을 수정 할 수 있다")
     void modifyGroup(String description, Long givenGroupId, GroupModificationRequest givenGroupModificationRequest, Group expectedGroup) {
         // given
+        groupRepository.save(Group.builder().name("name").description("").owner(testUser).build());
         String path = "/api/groups/";
         RequestSpecification givenRequest = RestAssured.given()
                                                        .baseUri(BASE_URL)

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -5,6 +5,8 @@ import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.user.domain.User;
+import com.postsquad.scoup.web.user.repository.UserRepository;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -29,12 +31,26 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
     @Autowired
     GroupRepository groupRepository;
 
+    @Autowired
+    UserRepository userRepository;
+
+    // temporary token with sub(userId) = 1, exp = 2023-01-01T00:00:00.000(Korean Standard Time)
+    private static String TEST_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjcyNDk4ODAwfQ.DXojMeUGIq77XWvQK0luZtZhsi-c6s9qjiiu9vHhkbg";
+    private static User TEST_USER = User.builder()
+                                        .nickname("nickname")
+                                        .email("email@email.com")
+                                        .password("password")
+                                        .avatarUrl("url")
+                                        .username("username")
+                                        .build();
+
     @BeforeEach
     void setUp() {
         groupRepository.save(Group.builder()
                                   .name("name")
                                   .description("description")
                                   .build());
+        userRepository.save(TEST_USER);
     }
 
     @AfterEach
@@ -53,6 +69,8 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                                        .port(port)
                                                        .basePath(path)
                                                        .contentType(ContentType.JSON)
+                                                       .header("Accept-Language", "en-US")
+                                                       .header("Authorization", TEST_TOKEN)
                                                        .body(givenGroupCreationRequest);
 
         // when
@@ -82,7 +100,9 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                         Group.builder()
                              .name("group name")
                              .description("description")
-                             .build()
+                             .owner(TEST_USER)
+                             .build(),
+                        TEST_USER
                 )
         );
     }
@@ -99,6 +119,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                                        .basePath(path)
                                                        .contentType(ContentType.JSON)
                                                        .header("Accept-Language", "en-US")
+                                                       .header("Authorization", TEST_TOKEN)
                                                        .body(givenGroupCreationRequest);
 
         // when
@@ -145,6 +166,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                                        .basePath(path)
                                                        .contentType(ContentType.JSON)
                                                        .header("Accept-Language", "en-US")
+                                                       .header("Authorization", TEST_TOKEN)
                                                        .body(givenGroupCreationRequest);
 
         // when
@@ -179,4 +201,58 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                 )
         );
     }
+
+    // 일단 엔티티에 오너 추가
+    // 그룹 생성시에 토큰에서 유저아이디 꺼내서 오너 등록
+    // 토큰에 있는 유저 아이디로 유저 조회
+    // 수정할 그룹의 오너인지 확인
+    // 그룹 수정
+//    @ParameterizedTest
+//    @MethodSource("modifyGroupProvider")
+//    @DisplayName("사용자가 그룹을 수정 할 수 있다")
+//    void modifyGroup(String description, GroupModificationRequest givenGroupModificationRequest, Group expectedGroup) {
+//        // given
+//        // TODO: 헤더에 토큰 필요
+//        String path = "/api/group";
+//        RequestSpecification givenRequest = RestAssured.given()
+//                                                       .baseUri(BASE_URL)
+//                                                       .port(port)
+//                                                       .basePath(path)
+//                                                       .contentType(ContentType.JSON)
+//                                                       .header("Accept-Language", "en-US")
+//                                                       .header("Authorization", TEST_TOKEN)
+//                                                       .body(givenGroupModificationRequest);
+//
+//        // when
+//        Response actualResponse = givenRequest.when()
+//                                              .log().all()
+//                                              .put();
+//
+//        // then
+//        // TODO: 뭘 리턴하지? 일단은 수정된 그룹의 아이디를 리턴한다고 가정
+//        actualResponse.then()
+//                      .log().all()
+//                      .statusCode(HttpStatus.NO_CONTENT.value());
+//        then(groupRepository.findById(actualResponse.as(Long.class)).orElse(null))
+//                .as("그룹 수정: %s" + description)
+//                .usingRecursiveComparison()
+//                .ignoringFields(ignoringFieldsForResponse)
+//                .isEqualTo(expectedGroup);
+//    }
+//
+//    static Stream<Arguments> modifyGroupProvider() {
+//        return Stream.of(
+//                Arguments.of(
+//                        "성공",
+//                        GroupModificationRequest.builder()
+//                                                .name("modifiedName")
+//                                                .description("modified description")
+//                                                .build(),
+//                        Group.builder()
+//                             .name("modifiedName")
+//                             .description("modified description")
+//                             .build()
+//                )
+//        );
+//    }
 }

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -11,6 +11,7 @@ import com.postsquad.scoup.web.group.provider.CreateGroupWithExistingNameProvide
 import com.postsquad.scoup.web.group.provider.ModifyGroupProvider;
 import com.postsquad.scoup.web.group.provider.ValidateGroupCreationRequestProvider;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
+import com.postsquad.scoup.web.signin.service.SignInTokenGenerator;
 import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.user.repository.UserRepository;
@@ -18,7 +19,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +31,7 @@ import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     @Autowired
@@ -42,18 +42,18 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
 
     // temporary token with sub(userId) = 1, exp = 2023-01-01T00:00:00.000(Korean Standard Time)
     private static String TEST_TOKEN = "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiZXhwIjoxNjcyNDk4ODAwfQ.DXojMeUGIq77XWvQK0luZtZhsi-c6s9qjiiu9vHhkbg";
-    private User testUser;
+    private User testUser = User.builder()
+                                .nickname("nickname")
+                                .email("email@email.com")
+                                .password("password")
+                                .avatarUrl("url")
+                                .username("username")
+                                .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
+                                .build();
 
     @BeforeEach
     void setUp() {
-        testUser = userRepository.save(User.builder()
-                                           .nickname("nickname")
-                                           .email("email@email.com")
-                                           .password("password")
-                                           .avatarUrl("url")
-                                           .username("username")
-                                           .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
-                                           .build());
+          userRepository.save(testUser);
     }
 
     @ParameterizedTest

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -11,7 +11,6 @@ import com.postsquad.scoup.web.group.provider.CreateGroupWithExistingNameProvide
 import com.postsquad.scoup.web.group.provider.ModifyGroupProvider;
 import com.postsquad.scoup.web.group.provider.ValidateGroupCreationRequestProvider;
 import com.postsquad.scoup.web.group.repository.GroupRepository;
-import com.postsquad.scoup.web.signin.service.SignInTokenGenerator;
 import com.postsquad.scoup.web.user.domain.OAuthUser;
 import com.postsquad.scoup.web.user.domain.User;
 import com.postsquad.scoup.web.user.repository.UserRepository;
@@ -48,7 +47,7 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                 .password("password")
                                 .avatarUrl("url")
                                 .username("username")
-                                .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
+                                .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "")))
                                 .build();
 
     @BeforeEach

--- a/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
@@ -2,7 +2,7 @@ package com.postsquad.scoup.web.group.mapper;
 
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
-import org.junit.jupiter.api.DisplayName;
+import com.postsquad.scoup.web.user.domain.User;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -13,11 +13,19 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 public class GroupMapperTest {
 
+    private static final User TEST_OWNER = User.builder()
+                                               .nickname("nickname")
+                                               .username("username")
+                                               .email("email@email.com")
+                                               .avatarUrl("avatarUrl")
+                                               .password("password")
+                                               .build();
+
     @ParameterizedTest
     @MethodSource("groupCreationRequestToGroupProvider")
     void groupCreationRequestToGroup(GroupCreationRequest givenGroupCreationRequest, Group expectedGroup) {
         // when
-        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(givenGroupCreationRequest);
+        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(givenGroupCreationRequest, TEST_OWNER);
 
         // then
         then(group).usingRecursiveComparison()
@@ -28,13 +36,14 @@ public class GroupMapperTest {
         return Stream.of(
                 Arguments.of(
                         GroupCreationRequest.builder()
-                        .name("name")
-                        .description("description")
-                        .build(),
+                                            .name("name")
+                                            .description("description")
+                                            .build(),
                         Group.builder()
-                        .name("name")
-                        .description("description")
-                        .build()
+                             .name("name")
+                             .description("description")
+                             .owner(TEST_OWNER)
+                             .build()
                 )
         );
     }

--- a/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/mapper/GroupMapperTest.java
@@ -25,7 +25,7 @@ public class GroupMapperTest {
     @MethodSource("groupCreationRequestToGroupProvider")
     void groupCreationRequestToGroup(GroupCreationRequest givenGroupCreationRequest, Group expectedGroup) {
         // when
-        Group group = GroupMapper.INSTANCE.groupCreationRequestToGroup(givenGroupCreationRequest, TEST_OWNER);
+        Group group = GroupMapper.INSTANCE.map(givenGroupCreationRequest, TEST_OWNER);
 
         // then
         then(group).usingRecursiveComparison()

--- a/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
@@ -1,15 +1,17 @@
 package com.postsquad.scoup.web.group.provider;
 
-import com.postsquad.scoup.web.group.GroupAcceptanceTest;
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.domain.Group;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
+import com.postsquad.scoup.web.user.domain.User;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 
+import java.util.List;
 import java.util.stream.Stream;
 
-import static com.postsquad.scoup.web.group.GroupAcceptanceTest.TEST_USER;
 
 public class CreateGroupProvider implements ArgumentsProvider {
 
@@ -25,7 +27,14 @@ public class CreateGroupProvider implements ArgumentsProvider {
                         Group.builder()
                              .name("group name")
                              .description("description")
-                             .owner(TEST_USER)
+                             .owner(User.builder()
+                                        .nickname("nickname")
+                                        .email("email@email.com")
+                                        .password("password")
+                                        .avatarUrl("url")
+                                        .username("username")
+                                        .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
+                                        .build())
                              .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
@@ -33,7 +33,7 @@ public class CreateGroupProvider implements ArgumentsProvider {
                                         .password("password")
                                         .avatarUrl("url")
                                         .username("username")
-                                        .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "1")))
+                                        .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "")))
                                         .build())
                              .build()
                 )

--- a/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupProvider.java
@@ -1,0 +1,33 @@
+package com.postsquad.scoup.web.group.provider;
+
+import com.postsquad.scoup.web.group.GroupAcceptanceTest;
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+import static com.postsquad.scoup.web.group.GroupAcceptanceTest.TEST_USER;
+
+public class CreateGroupProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(
+                        "성공",
+                        GroupCreationRequest.builder()
+                                            .name("group name")
+                                            .description("description")
+                                            .build(),
+                        Group.builder()
+                             .name("group name")
+                             .description("description")
+                             .owner(TEST_USER)
+                             .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupWithExistingNameProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/CreateGroupWithExistingNameProvider.java
@@ -1,0 +1,31 @@
+package com.postsquad.scoup.web.group.provider;
+
+import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class CreateGroupWithExistingNameProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(
+                        "실패 - 이미 존재하는 그룹 이름",
+                        GroupCreationRequest.builder()
+                                            .name("name")
+                                            .description("description")
+                                            .build(),
+                        ErrorResponse.builder()
+                                     .message("Failed to create group")
+                                     .statusCode(400)
+                                     .errors(Arrays.asList("Group name 'name' already exists"))
+                                     .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/group/provider/ModifyGroupProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/ModifyGroupProvider.java
@@ -1,0 +1,30 @@
+package com.postsquad.scoup.web.group.provider;
+
+import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
+import com.postsquad.scoup.web.group.domain.Group;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+import java.util.stream.Stream;
+
+public class ModifyGroupProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(
+                        "성공",
+                        1L,
+                        GroupModificationRequest.builder()
+                                                .name("modifiedName")
+                                                .description("modified description")
+                                                .build(),
+                        Group.builder()
+                             .name("modifiedName")
+                             .description("modified description")
+                             .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/group/provider/ValidateGroupCreationRequestProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/group/provider/ValidateGroupCreationRequestProvider.java
@@ -1,0 +1,32 @@
+package com.postsquad.scoup.web.group.provider;
+
+import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.springframework.http.HttpStatus;
+
+import java.util.Collections;
+import java.util.stream.Stream;
+
+public class ValidateGroupCreationRequestProvider implements ArgumentsProvider {
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
+        return Stream.of(
+                Arguments.of(
+                        "실패",
+                        GroupCreationRequest.builder()
+                                            .name("")
+                                            .description("")
+                                            .build(),
+                        ErrorResponse.builder()
+                                     .message("Method argument not valid.")
+                                     .statusCode(HttpStatus.BAD_REQUEST.value())
+                                     .errors(Collections.singletonList("name: must not be empty"))
+                                     .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
@@ -16,6 +16,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -40,8 +41,8 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
     @Autowired
     UserRepository userRepository;
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         userRepository.deleteAll();
     }
 

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -31,6 +31,7 @@ class UserAcceptanceTest extends AcceptanceTestBase {
 
     @BeforeEach
     void setUp() {
+        userRepository.deleteAll();
         userRepository.save(User.builder()
                                 .nickname("existing")
                                 .username("username")
@@ -38,11 +39,6 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                                 .avatarUrl("avatarUrl")
                                 .password("password")
                                 .build());
-    }
-
-    @AfterEach
-    void tearDown() {
-        userRepository.deleteAll();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
그룹 수정기능 우선 성공케이스 완료했습니다. 이래저래 삽질을 많이 하다보니 PR 많이 늦어진 점 죄송합니다ㅠㅠ

인터셉터를 사용해 토큰에서 유저 정보를 가져와 setAttribute로 로그인된 유저를 저장합니다.
컨트롤러에서 로그인된 유저 정보가 필요할 때 `@LoggedInUser`를 사용해 저장된 유저를 불러옵니다.
그룹생성과 수정 모두 적용하였습니다.

그룹 인수테스트에서는 미리 생성해둔 아이디값 1, 만료일 2023-01-01T00:00:00.000인 토큰과 테스트 유저를 사용합니다.
인수테스트에서 그룹을 비교시 오너의 필드들은 ignoringFields에 해당하지 않으므로 오너는 따로 비교해주었습니다.

구현하다보니 든 생각인데 처음에 GroupModificationRequest라고 정해놓아서 정해놓았던 crud의 update와 다소 헷갈릴 수 있을 것 같습니다.
