### PR TITLE
[Jane] Database 초기화 로직을 AcceptanceTestBase에 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor  'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    implementation "com.google.guava:guava:16+"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     testImplementation 'io.rest-assured:rest-assured'
+    testImplementation 'com.google.guava:guava:16+'
     implementation 'com.nimbusds:nimbus-jose-jwt'
 
     /* MapStruct
@@ -55,8 +56,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor  'org.projectlombok:lombok-mapstruct-binding:0.2.0'
-
-    implementation "com.google.guava:guava:16+"
 }
 
 test {

--- a/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
+++ b/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
@@ -5,6 +5,7 @@ import io.restassured.RestAssured;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.config.RestAssuredConfig;
 import io.restassured.internal.mapping.Jackson2Mapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -16,6 +17,19 @@ public class AcceptanceTestBase {
 
     @LocalServerPort
     protected int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @BeforeEach
+    void cleanUpDatabase() {
+        if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+            RestAssured.port = port;
+            databaseCleanup.afterPropertiesSet();
+        }
+
+        databaseCleanup.execute();
+    }
 
     @Autowired
     protected ObjectMapper objectMapper;

--- a/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
+++ b/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
@@ -23,11 +23,6 @@ public class AcceptanceTestBase {
 
     @BeforeEach
     void cleanUpDatabase() {
-        if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
-            RestAssured.port = port;
-            databaseCleanup.afterPropertiesSet();
-        }
-
         databaseCleanup.execute();
     }
 

--- a/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
+++ b/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
@@ -33,11 +33,11 @@ public class DatabaseCleanup implements InitializingBean {
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
 
         for (String tableName : tableNames) {
-            entityManager.createNativeQuery("TRUNCATE TABLE " + "\"" + tableName + "\"").executeUpdate();
-            entityManager.createNativeQuery("ALTER TABLE " + "\"" + tableName + "\"" + " ALTER COLUMN " + "\"id\"" + " RESTART WITH 1").executeUpdate();
+            entityManager.createNativeQuery("TRUNCATE TABLE \"" + tableName + "\"").executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE \"" + tableName + "\" ALTER COLUMN \"id\" RESTART WITH 1").executeUpdate();
         }
 
-        entityManager.createNativeQuery("TRUNCATE TABLE " + "\"" + "oauth_user" + "\"").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE \"oauth_user\"").executeUpdate();
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }
 }

--- a/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
+++ b/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
@@ -1,0 +1,43 @@
+package com.postsquad.scoup.web;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class DatabaseCleanup implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+                                  .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                                  .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+                                  .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + "\"" + tableName + "\"").executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + "\"" + tableName + "\"" + " ALTER COLUMN " + "\"id\"" + " RESTART WITH 1").executeUpdate();
+        }
+
+        entityManager.createNativeQuery("TRUNCATE TABLE " + "\"" + "oauth_user" + "\"").executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
+++ b/src/test/java/com/postsquad/scoup/web/DatabaseCleanup.java
@@ -1,10 +1,10 @@
 package com.postsquad.scoup.web;
 
 import com.google.common.base.CaseFormat;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.PostConstruct;
 import javax.persistence.Entity;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -12,15 +12,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-public class DatabaseCleanup implements InitializingBean {
+public class DatabaseCleanup {
 
     @PersistenceContext
     private EntityManager entityManager;
 
     private List<String> tableNames;
 
-    @Override
-    public void afterPropertiesSet() {
+    @PostConstruct
+    public void init() {
         tableNames = entityManager.getMetamodel().getEntities().stream()
                                   .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
                                   .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))

--- a/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/group/GroupAcceptanceTest.java
@@ -37,11 +37,6 @@ public class GroupAcceptanceTest extends AcceptanceTestBase {
                                   .build());
     }
 
-    @AfterEach
-    void tearDown() {
-        groupRepository.deleteAll();
-    }
-
     @ParameterizedTest
     @MethodSource("createGroupProvider")
     @DisplayName("사용자가 새로운 그룹을 생성할 수 있다.")

--- a/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/signin/SignInAcceptanceTest.java
@@ -40,11 +40,6 @@ class SignInAcceptanceTest extends AcceptanceTestBase {
     @Autowired
     UserRepository userRepository;
 
-    @AfterEach
-    void tearDown() {
-        userRepository.deleteAll();
-    }
-
     private long signUp(SignUpRequest signUpRequest) {
         String path = "/api/users";
         return RestAssured.given()

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -40,11 +40,6 @@ class UserAcceptanceTest extends AcceptanceTestBase {
                                 .build());
     }
 
-    @AfterEach
-    void tearDown() {
-        userRepository.deleteAll();
-    }
-
     @ParameterizedTest
     @ArgumentsSource(EmailSignUpProvider.class)
     @DisplayName("신규 사용자는 이메일을 통해 회원가입을 할 수 있다")


### PR DESCRIPTION
Database 초기화 로직을 AcceptanceTestBase에 추가했습니다.

```
spring.jpa.properties.hibernate.globally_quoted_identifiers=true
```
application.properties에 위와 같이 설정해두어 네이티브 쿼리 실행 시 다소 따옴표가 지저분하게 들어갔습니다. 
추가로 oauth_user 테이블만 o_auth_user가 아닌 oauth_user로 네이밍이 되어있고, id가 존재하지 않아 따로 처리해주었습니다. 
```java
    @Transactional
    public void execute() {
        entityManager.flush();
        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();

        for (String tableName : tableNames) {
            entityManager.createNativeQuery("TRUNCATE TABLE \"" + tableName + "\"").executeUpdate();
            entityManager.createNativeQuery("ALTER TABLE \"" + tableName + "\" ALTER COLUMN \"id\" RESTART WITH 1").executeUpdate();
        }

        entityManager.createNativeQuery("TRUNCATE TABLE \"oauth_user\"").executeUpdate();
        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
    }
```
Closes #142
Closes #144 