### PR TITLE
[Freddie] query param 처리용 Argument resovler 추가

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/common/ObjectMapperUtils.java
+++ b/src/main/java/com/postsquad/scoup/web/common/ObjectMapperUtils.java
@@ -1,0 +1,36 @@
+package com.postsquad.scoup.web.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class ObjectMapperUtils {
+
+    private final ObjectMapper objectMapper;
+
+    public <T> T convertRequestParameterToObject(Map<String, String[]> parameterMap, Class<T> typeToConvert) {
+        Map<String, Object> methodParameterForConvert = parameterMap.entrySet().parallelStream()
+                                                                    .collect(Collectors.toMap(
+                                                                            Map.Entry::getKey,
+                                                                            mapSingleArrayValueToString()
+                                                                    ));
+
+        return objectMapper.convertValue(methodParameterForConvert, typeToConvert);
+    }
+
+    private Function<Map.Entry<String, String[]>, Object> mapSingleArrayValueToString() {
+        return entry -> {
+            if (entry.getValue().length == 1) {
+                return entry.getValue()[0];
+            }
+            // 길이가 1이 아닌 경우는 배열로 반환하여 리스트로 매핑되도록 함.
+            return entry.getValue();
+        };
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
+++ b/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.postsquad.scoup.web.config;
+
+import com.postsquad.scoup.web.common.ObjectMapperUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * 리퀘스트 파라미터(@RequestParam으로 바인딩)에 사용되는 객체를 ServletRequestDataBinder 대신 처리한다.
+ * primitive type 이 아닌 경우 ObjectMapper 를 이용하여 매핑하도록 설정.
+ * 내부 정책과 다르게 매핑되는 쿼리 파라미터 매핑이 가능해짐.<br/>
+ * - ServletRequestDataBinder 에서 처리할 경우 리플렉션으로 처리된다. 따라서 내부 정책이 snake case 인 경우 일반적인 방법으로 인식불가능하다.<br/>
+ * - 따라서 원시값이 아닌경우 ObjectMapper를 이용하면 해당 Mapper에 설정된 대로 매핑가능.
+ */
+@RequiredArgsConstructor
+@Component
+public class RequestParameterArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final ObjectMapperUtils objectMapperUtils;
+
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return !parameter.getParameterType().isPrimitive();
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        return objectMapperUtils.convertRequestParameterToObject(webRequest.getParameterMap(), parameter.getParameterType());
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -7,14 +7,19 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import reactor.netty.http.client.HttpClient;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    private final RequestParameterArgumentResolver requestParameterArgumentResolver;
 
     @Bean
     public HttpClient httpClient() {
@@ -27,5 +32,10 @@ public class WebConfig implements WebMvcConfigurer {
                                                                   .codecs(configurer -> configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(baseConfig)))
                                                                   .build();
         return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient)).exchangeStrategies(exchangeStrategies).build();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(requestParameterArgumentResolver);
     }
 }

--- a/src/test/java/com/postsquad/scoup/web/common/ObjectMapperUtilsTest.java
+++ b/src/test/java/com/postsquad/scoup/web/common/ObjectMapperUtilsTest.java
@@ -1,0 +1,52 @@
+package com.postsquad.scoup.web.common;
+
+import com.postsquad.scoup.web.schedule.controller.request.ScheduleCandidateReadRequest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+@SpringBootTest
+class ObjectMapperUtilsTest {
+
+    @Autowired
+    ObjectMapperUtils objectMapperUtils;
+
+    @ParameterizedTest
+    @MethodSource("convertRequestParameterToObjectProvider")
+    void convertRequestParameterToObject(
+            Map<String, String[]> givenParameterMap,
+            Class<?> givenTypeToConvert,
+            Object expectedConvertedObject
+    ) {
+        // when
+        Object actualConvertedObject = objectMapperUtils.convertRequestParameterToObject(givenParameterMap, givenTypeToConvert);
+
+        // then
+        then(actualConvertedObject).usingRecursiveComparison()
+                                   .isEqualTo(expectedConvertedObject);
+    }
+
+    static Stream<Arguments> convertRequestParameterToObjectProvider() {
+        return Stream.of(
+                Arguments.arguments(
+                        Map.of(
+                                "start_date", new String[]{"2021-09-10"},
+                                "end_date", new String[]{"2021-09-10"}
+                        ),
+                        ScheduleCandidateReadRequest.class,
+                        ScheduleCandidateReadRequest.builder()
+                                                    .startDate(LocalDate.of(2021, 9, 10))
+                                                    .endDate(LocalDate.of(2021, 9, 10))
+                                                    .build()
+                )
+        );
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/common/ObjectMapperUtilsTest.java
+++ b/src/test/java/com/postsquad/scoup/web/common/ObjectMapperUtilsTest.java
@@ -1,6 +1,5 @@
 package com.postsquad.scoup.web.common;
 
-import com.postsquad.scoup.web.schedule.controller.request.ScheduleCandidateReadRequest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -41,11 +40,11 @@ class ObjectMapperUtilsTest {
                                 "start_date", new String[]{"2021-09-10"},
                                 "end_date", new String[]{"2021-09-10"}
                         ),
-                        ScheduleCandidateReadRequest.class,
-                        ScheduleCandidateReadRequest.builder()
-                                                    .startDate(LocalDate.of(2021, 9, 10))
-                                                    .endDate(LocalDate.of(2021, 9, 10))
-                                                    .build()
+                        RequestDtoForConvertRequestParameterToObjectTest.class,
+                        new RequestDtoForConvertRequestParameterToObjectTest(
+                                LocalDate.of(2021, 9, 10),
+                                LocalDate.of(2021, 9, 10)
+                        )
                 )
         );
     }

--- a/src/test/java/com/postsquad/scoup/web/common/RequestDtoForConvertRequestParameterToObjectTest.java
+++ b/src/test/java/com/postsquad/scoup/web/common/RequestDtoForConvertRequestParameterToObjectTest.java
@@ -1,0 +1,34 @@
+package com.postsquad.scoup.web.common;
+
+import java.time.LocalDate;
+
+public class RequestDtoForConvertRequestParameterToObjectTest {
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    public RequestDtoForConvertRequestParameterToObjectTest() {
+    }
+
+    public RequestDtoForConvertRequestParameterToObjectTest(LocalDate startDate, LocalDate endDate) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+}


### PR DESCRIPTION
Argument resovler 내부에서 변환해주는 ObjectMapper는 Util로 만들어서 컴포넌트로 등록했습니다.

여러 이유가 있지만 가장 큰 이유는 테스트 코드가 있었으면 했어요. 그리고 테스트 코드때문에 분리하더라도 계속 사용할 수 있는 구조이기 때문에 의미가 있을거라 생각했습니다.

RequestParameterArgumentResolver는 테스트 코드가 없는데요. 고민을 하다가 일단 그냥 올렸습니다.

만약 테스트를 한다면 MockMvc를 이용해서 정상적으로 작동하는지 확인 해볼 수 있을 것 같고, 혹은 수동으로 매개변수를 꾸며서 사용해볼 수 있을 것 같아요. 그런데 후자는 코드가 장황해질 수 있을 것 같습니다.

잘 생각해보니 스프링에서 관리하는 Bean을 그대로 가져와서 매개변수로 넣는 식의 테스트도 해볼 수 있겠네요

