### PR TITLE
[Freddie] 스케줄 후보의 color code 제거, 스케줄 빌더에서 color code 기본값 처리

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/schedule/domain/Schedule.java
+++ b/src/main/java/com/postsquad/scoup/web/schedule/domain/Schedule.java
@@ -9,6 +9,7 @@ import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -51,6 +52,11 @@ public class Schedule extends BaseEntity {
 
     @Builder
     public static Schedule of(Group group, String title, String description, LocalDateTime dueDateTime, String colorCode, ConfirmedSchedule confirmedSchedule, @Singular List<ScheduleCandidate> scheduleCandidates) {
+
+        if (Objects.isNull(colorCode)) {
+            colorCode = DEFAULT_COLOR_CODE;
+        }
+
         Schedule schedule = new Schedule(group, title, description, dueDateTime, colorCode, confirmedSchedule);
         schedule.addScheduleCandidates(scheduleCandidates);
         return schedule;

--- a/src/main/java/com/postsquad/scoup/web/schedule/domain/ScheduleCandidate.java
+++ b/src/main/java/com/postsquad/scoup/web/schedule/domain/ScheduleCandidate.java
@@ -2,7 +2,6 @@ package com.postsquad.scoup.web.schedule.domain;
 
 import com.postsquad.scoup.web.common.BaseEntity;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
@@ -14,29 +13,23 @@ import java.time.LocalDateTime;
 @Entity
 public class ScheduleCandidate extends BaseEntity {
 
-    private static final String DEFAULT_COLOR_CODE = "#00ff0000";
-
     @ManyToOne
     @JoinColumn(name = "schedule_id")
     @Setter
     private Schedule schedule;
 
-    @ColumnDefault("'" + DEFAULT_COLOR_CODE + "'")
-    private String colorCode;
-
     private LocalDateTime startDateTime;
 
     private LocalDateTime endDateTime;
 
-    public ScheduleCandidate(Schedule schedule, String colorCode, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public ScheduleCandidate(Schedule schedule, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         this.schedule = schedule;
-        this.colorCode = colorCode;
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
     }
 
     @Builder
-    public static ScheduleCandidate of(Schedule schedule, String colorCode, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return new ScheduleCandidate(schedule, colorCode, startDateTime, endDateTime);
+    public static ScheduleCandidate of(Schedule schedule, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return new ScheduleCandidate(schedule, startDateTime, endDateTime);
     }
 }

--- a/src/test/java/com/postsquad/scoup/web/schedule/ScheduleCandidateAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/schedule/ScheduleCandidateAcceptanceTest.java
@@ -134,6 +134,7 @@ class ScheduleCandidateAcceptanceTest extends AcceptanceTestBase {
                                                                                 .endDateTime(readAllTestData.scheduleCandidate1().getEndDateTime())
                                                                                 .isConfirmed(false)
                                                                                 .scheduleTitle("title")
+                                                                                .colorCode("#00ff0000")
                                                                                 .build()
                                         ))
                         )


### PR DESCRIPTION
@janeljs 의 작업 중 #180 에서 반영되지 않은 부분이 있어 추가 PR 날립니다!
리뷰에서 이 부분도 체크해드렸어야 했는데, 제가 빼먹은 것 같아요.

- 스케줄 후보의 color code 제거했습니다
- 빌더에서 color code null일경우 기본값 넣어주도록 추가했습니다.