### PR TITLE
[Freddie] RequestArugmentsResolver에서 Validation 처리하도록 수정

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
+++ b/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
@@ -1,27 +1,38 @@
 package com.postsquad.scoup.web.config;
 
 import com.postsquad.scoup.web.common.ObjectMapperUtils;
-import lombok.RequiredArgsConstructor;
+import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
-import org.springframework.stereotype.Component;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
+import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
+
+import java.util.List;
 
 /**
  * 리퀘스트 파라미터(@RequestParam으로 바인딩)에 사용되는 객체를 ServletRequestDataBinder 대신 처리한다.
  * primitive type 이 아닌 경우 ObjectMapper 를 이용하여 매핑하도록 설정.
  * 내부 정책과 다르게 매핑되는 쿼리 파라미터 매핑이 가능해짐.<br/>
  * - ServletRequestDataBinder 에서 처리할 경우 리플렉션으로 처리된다. 따라서 내부 정책이 snake case 인 경우 일반적인 방법으로 인식불가능하다.<br/>
- * - 따라서 원시값이 아닌경우 ObjectMapper를 이용하면 해당 Mapper에 설정된 대로 매핑가능.
+ * - 따라서 원시값이 아닌경우 ObjectMapper를 이용하면 해당 Mapper에 설정된 대로 매핑가능.<br/>
+ * <br/>
+ * RequestBody, ResponseBody 어노테이션이 붙은 경우 RequestResponseBodyMethodProcessor에서 처리하게 된다. 이를 상속하여 내부 로직을 그대로 사용하도록 함.<br/>
+ * - HTTP 메세지가 아닌 argument만 변환하고 있는데, 추후 헤더 설정 등에서 막힐경우 확인 필요.<br/>
+ * - 생성자에 Advice를 넣어주지 않고 있는데 해당 부분에서 오류발생 시 수정 필요.<br/>
  */
-@RequiredArgsConstructor
-@Component
-public class RequestParameterArgumentResolver implements HandlerMethodArgumentResolver {
+public class RequestParameterArgumentResolver extends RequestResponseBodyMethodProcessor {
 
-    private final ObjectMapperUtils objectMapperUtils;
+    private ObjectMapperUtils objectMapperUtils;
 
+    public RequestParameterArgumentResolver(ObjectMapperUtils objectMapperUtils, List<HttpMessageConverter<?>> converters) {
+        super(converters);
+        this.objectMapperUtils = objectMapperUtils;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -29,7 +40,25 @@ public class RequestParameterArgumentResolver implements HandlerMethodArgumentRe
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
-        return objectMapperUtils.convertRequestParameterToObject(webRequest.getParameterMap(), parameter.getParameterType());
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+        parameter = parameter.nestedIfOptional();
+        Object arg = objectMapperUtils.convertRequestParameterToObject(webRequest.getParameterMap(), parameter.getParameterType());
+        String name = Conventions.getVariableNameForParameter(parameter);
+
+        if (binderFactory != null) {
+            WebDataBinder binder = binderFactory.createBinder(webRequest, arg, name);
+            if (arg != null) {
+                validateIfApplicable(binder, parameter);
+                if (binder.getBindingResult().hasErrors() && isBindExceptionRequired(binder, parameter)) {
+                    throw new MethodArgumentNotValidException(parameter, binder.getBindingResult());
+                }
+            }
+            if (mavContainer != null) {
+                mavContainer.addAttribute(BindingResult.MODEL_KEY_PREFIX + name, binder.getBindingResult());
+            }
+        }
+
+        return adaptArgumentIfNecessary(arg, parameter);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
+++ b/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
@@ -4,6 +4,7 @@ import com.postsquad.scoup.web.common.ObjectMapperUtils;
 import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.WebDataBinder;
@@ -25,11 +26,12 @@ import java.util.List;
  * - HTTP 메세지가 아닌 argument만 변환하고 있는데, 추후 헤더 설정 등에서 막힐경우 확인 필요.<br/>
  * - 생성자에 Advice를 넣어주지 않고 있는데 해당 부분에서 오류발생 시 수정 필요.<br/>
  */
+@Component
 public class RequestParameterArgumentResolver extends RequestResponseBodyMethodProcessor {
 
     private ObjectMapperUtils objectMapperUtils;
 
-    public RequestParameterArgumentResolver(ObjectMapperUtils objectMapperUtils, List<HttpMessageConverter<?>> converters) {
+    public RequestParameterArgumentResolver(List<HttpMessageConverter<?>> converters, ObjectMapperUtils objectMapperUtils) {
         super(converters);
         this.objectMapperUtils = objectMapperUtils;
     }

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.postsquad.scoup.web.common.ObjectMapperUtils;
 import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
 import io.netty.resolver.DefaultAddressResolverGroup;
@@ -12,6 +13,7 @@ import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.hateoas.mediatype.collectionjson.CollectionJsonLinkDiscoverer;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.plugin.core.SimplePluginRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -30,9 +32,11 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final String[] SIGNIN_PATH_TO_EXCLUDE = {"/sign-in/**", "/users/**", "/oauth/**", "/h2-console/**", "/swagger-ui.html", "/v2/api-docs", "/swagger-resources/**", "/webjars/**"};
 
-    private final RequestParameterArgumentResolver requestParameterArgumentResolver;
-
     private final SignInInterceptor signInInterceptor;
+
+    private final ObjectMapperUtils objectMapperUtils;
+
+    private final MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter;
 
     @Bean
     public HttpClient httpClient() {
@@ -57,7 +61,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserArgumentResolver());
-        resolvers.add(requestParameterArgumentResolver);
+        resolvers.add(new RequestParameterArgumentResolver(objectMapperUtils, List.of(mappingJackson2HttpMessageConverter)));
     }
 
     @Override

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -1,7 +1,6 @@
 package com.postsquad.scoup.web.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.postsquad.scoup.web.common.ObjectMapperUtils;
 import com.postsquad.scoup.web.signin.controller.SignInInterceptor;
 import com.postsquad.scoup.web.user.UserArgumentResolver;
 import io.netty.resolver.DefaultAddressResolverGroup;
@@ -13,7 +12,6 @@ import org.springframework.hateoas.client.LinkDiscoverers;
 import org.springframework.hateoas.mediatype.collectionjson.CollectionJsonLinkDiscoverer;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.plugin.core.SimplePluginRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -34,9 +32,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final SignInInterceptor signInInterceptor;
 
-    private final ObjectMapperUtils objectMapperUtils;
-
-    private final MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter;
+    private final RequestParameterArgumentResolver requestParameterArgumentResolver;
 
     @Bean
     public HttpClient httpClient() {
@@ -61,7 +57,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(new UserArgumentResolver());
-        resolvers.add(new RequestParameterArgumentResolver(objectMapperUtils, List.of(mappingJackson2HttpMessageConverter)));
+        resolvers.add(requestParameterArgumentResolver);
     }
 
     @Override


### PR DESCRIPTION
RequestParameter로 받은 객체에서 Valid 어노테이션이 사용 가능하도록 수정했습니다.

`RequestResponseBodyMethodProcessor` 내부 로직을 옮겨왔는데, 차이점은 `Object arg`를 가져올 때 메세지 컨버터를 사용하지 않고 `ObjectMapperUtils` 를 이용합니다. 메세지 컨버터의 내부를 살펴보니 HTTP 메세지의 바디를 읽어오도록 되어있어 URL에 붙어있는 쿼리 파라미터는 찾아오지 못하기 때문입니다. 사용 시 null이 반환됩니다.
이외에는 그대로 가져왔습니다.

개인적인 생각으로는 코드 중복이 발생하여 좋지 않아보이기는 한데, `RequestResponseBodyMethodProcessor` 의 `resolveArgument` 를 그대로 사용할 마땅한 방법이 없어 일단은 이런식으로 구성했습니다. 
처리 전에 메세지 바디에 파라미터를 직접 넣어주는 방법도 있을 것 같은데 좋은 방법인지는 잘 모르겠습니다.

그리고 Advice를 생성자에 추가해주지 않아 관련 문제가 생길 수 있을 것 같습니다. 어떻게 테스트해봐야할지 감이 오지 않아서 일단 여기까지 작업하고 pr 올리겠습니다.