### PR TITLE
[Jane] QueryDSL 의존성 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,13 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
     implementation group: 'org.springframework.plugin', name: 'spring-plugin-core', version: '1.2.0.RELEASE'
+
+    /* Querydsl */
+    implementation group: 'com.querydsl', name: 'querydsl-apt', version: '4.4.0'
+    implementation group: 'com.querydsl', name: 'querydsl-jpa', version: '4.4.0'
+    annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', classifier:'jpa', version: '4.4.0'
+    annotationProcessor group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '1.3.5'
+    annotationProcessor group: 'jakarta.persistence', name: 'jakarta.persistence-api', version: '2.2.3'
 }
 
 test {

--- a/src/main/java/com/postsquad/scoup/web/config/QueryDslConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.postsquad.scoup.web.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/postsquad/scoup/web/schedule/repository/ConfirmedScheduleRepository.java
+++ b/src/main/java/com/postsquad/scoup/web/schedule/repository/ConfirmedScheduleRepository.java
@@ -2,11 +2,16 @@ package com.postsquad.scoup.web.schedule.repository;
 
 import com.postsquad.scoup.web.schedule.domain.ConfirmedSchedule;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-
 public interface ConfirmedScheduleRepository extends JpaRepository<ConfirmedSchedule, Long> {
 
-    List<ConfirmedSchedule> findConfirmedSchedulesBySchedule_Group_Id(Long id);
+    @Query("select cs from ConfirmedSchedule cs" +
+           " join fetch cs.schedule s" +
+           " where cs.schedule.group.id = :id"
+    )
+    List<ConfirmedSchedule> findConfirmedSchedulesByGroupId(@Param("id") Long id);
 }

--- a/src/main/java/com/postsquad/scoup/web/schedule/service/ConfirmedScheduleService.java
+++ b/src/main/java/com/postsquad/scoup/web/schedule/service/ConfirmedScheduleService.java
@@ -17,7 +17,7 @@ public class ConfirmedScheduleService {
     private final ConfirmedScheduleRepository confirmedScheduleRepository;
 
     public ConfirmedScheduleReadAllResponses readAll(Long groupId) {
-        List<ConfirmedScheduleReadAllResponse> confirmedSchedules = confirmedScheduleRepository.findConfirmedSchedulesBySchedule_Group_Id(groupId)
+        List<ConfirmedScheduleReadAllResponse> confirmedSchedules = confirmedScheduleRepository.findConfirmedSchedulesByGroupId(groupId)
                                                                                                .stream()
                                                                                                .map(ConfirmedScheduleReadAllResponseMapper.INSTANCE::map)
                                                                                                .collect(Collectors.toList());

--- a/src/test/java/com/postsquad/scoup/web/schedule/ConfirmedScheduleAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/schedule/ConfirmedScheduleAcceptanceTest.java
@@ -2,11 +2,14 @@ package com.postsquad.scoup.web.schedule;
 
 import com.postsquad.scoup.web.AcceptanceTestBase;
 import com.postsquad.scoup.web.TestEntityManager;
+import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.group.domain.Group;
 import com.postsquad.scoup.web.schedule.controller.response.ConfirmedScheduleReadAllResponses;
 import com.postsquad.scoup.web.schedule.domain.ConfirmedSchedule;
 import com.postsquad.scoup.web.schedule.domain.Schedule;
 import com.postsquad.scoup.web.schedule.provider.ConfirmedScheduleReadAllProvider;
+import com.postsquad.scoup.web.user.domain.OAuthUser;
+import com.postsquad.scoup.web.user.domain.User;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
@@ -29,6 +32,15 @@ class ConfirmedScheduleAcceptanceTest extends AcceptanceTestBase {
     @Autowired
     TestEntityManager testEntityManager;
 
+    protected User testUser2 = User.builder()
+                                  .nickname("nickname2")
+                                  .email("email2@email.com")
+                                  .password("password2")
+                                  .avatarUrl("url2")
+                                  .username("username2")
+                                  .oAuthUsers(List.of(OAuthUser.of(OAuthType.NONE, "")))
+                                  .build();
+
     @ParameterizedTest
     @ArgumentsSource(ConfirmedScheduleReadAllProvider.class)
     @DisplayName("확정된 일정을 조회할 수 있다")
@@ -36,6 +48,7 @@ class ConfirmedScheduleAcceptanceTest extends AcceptanceTestBase {
                                    ConfirmedScheduleReadAllResponses expectedConfirmedScheduleReadAllResponses) {
         // given
         testEntityManager.persist(testUser);
+        testEntityManager.persist(testUser2);
 
         Group group = Group.builder()
                            .name("name")
@@ -55,7 +68,7 @@ class ConfirmedScheduleAcceptanceTest extends AcceptanceTestBase {
         ConfirmedSchedule confirmedSchedule = ConfirmedSchedule.builder()
                                                                .startDateTime(LocalDateTime.of(2021, 9, 25, 9, 0))
                                                                .endDateTime(LocalDateTime.of(2021, 9, 25, 11, 0))
-                                                               .confirmedParticipants(List.of(testUser))
+                                                               .confirmedParticipants(List.of(testUser, testUser2))
                                                                .build();
         schedule.confirmSchedule(confirmedSchedule);
         testEntityManager.persist(group);

--- a/src/test/java/com/postsquad/scoup/web/schedule/provider/ConfirmedScheduleReadAllProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/schedule/provider/ConfirmedScheduleReadAllProvider.java
@@ -28,7 +28,13 @@ public class ConfirmedScheduleReadAllProvider implements ArgumentsProvider {
                                                                                                                ConfirmedParticipantResponse.builder()
                                                                                                                                            .nickname("nickname")
                                                                                                                                            .username("username")
-                                                                                                                                           .build()))
+                                                                                                                                           .build(),
+                                                                                                               ConfirmedParticipantResponse.builder()
+                                                                                                                                           .nickname("nickname2")
+                                                                                                                                           .username("username2")
+                                                                                                                                           .build())
+
+                                                                                                       )
                                                                                                        .build()))
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/schedule/repository/ConfirmedScheduleRepositoryTest.java
+++ b/src/test/java/com/postsquad/scoup/web/schedule/repository/ConfirmedScheduleRepositoryTest.java
@@ -47,7 +47,7 @@ class ConfirmedScheduleRepositoryTest {
         Long groupId = confirmedSchedule.getSchedule().getGroup().getId();
 
         // when
-        List<ConfirmedSchedule> actualConfirmedSchedules = confirmedScheduleRepository.findConfirmedSchedulesBySchedule_Group_Id(groupId);
+        List<ConfirmedSchedule> actualConfirmedSchedules = confirmedScheduleRepository.findConfirmedSchedulesByGroupId(groupId);
 
         // then
         then(actualConfirmedSchedules.get(0))


### PR DESCRIPTION
QueryDSL 의존성 및 설정을 추가했습니다.

아래 블로그들을 보면 추가로 클랜 태스크를 실행하는 것 같은데 예전에 [프레디께서 공유해주셨던 자료](https://github.com/Im-D/your-voice-back/commit/fd2ee911a7f6acf74305a5fde77fde00f3778134) 해당 태스크 실행 없이도 잘 동작하는 것 같아 일단 해당 부분만 추가하였습니다.

- https://jojoldu.tistory.com/538
- http://honeymon.io/tech/2020/07/09/gradle-annotation-processor-with-querydsl.html