### PR TITLE
[Jane] Querydsl 의존성 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,13 @@ dependencies {
     implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
     implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
     implementation group: 'org.springframework.plugin', name: 'spring-plugin-core', version: '1.2.0.RELEASE'
+
+    /* Querydsl */
+    implementation group: 'com.querydsl', name: 'querydsl-apt', version: '4.4.0'
+    implementation group: 'com.querydsl', name: 'querydsl-jpa', version: '4.4.0'
+    annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', classifier:'jpa', version: '4.4.0'
+    annotationProcessor group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '1.3.5'
+    annotationProcessor group: 'jakarta.persistence', name: 'jakarta.persistence-api', version: '2.2.3'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -63,11 +63,11 @@ dependencies {
     implementation group: 'org.springframework.plugin', name: 'spring-plugin-core', version: '1.2.0.RELEASE'
 
     /* Querydsl */
-    implementation group: 'com.querydsl', name: 'querydsl-apt', version: '4.4.0'
-    implementation group: 'com.querydsl', name: 'querydsl-jpa', version: '4.4.0'
-    annotationProcessor group: 'com.querydsl', name: 'querydsl-apt', classifier:'jpa', version: '4.4.0'
-    annotationProcessor group: 'jakarta.annotation', name: 'jakarta.annotation-api', version: '1.3.5'
-    annotationProcessor group: 'jakarta.persistence', name: 'jakarta.persistence-api', version: '2.2.3'
+    implementation 'com.querydsl:querydsl-apt'
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor 'com.querydsl:querydsl-apt:jpa'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     /* Querydsl */
     implementation 'com.querydsl:querydsl-apt'
     implementation 'com.querydsl:querydsl-jpa'
-    annotationProcessor 'com.querydsl:querydsl-apt:jpa'
+    annotationProcessor 'com.querydsl:querydsl-apt::jpa'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }

--- a/src/main/java/com/postsquad/scoup/web/config/QuerydslConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.postsquad.scoup.web.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
Querydsl 의존성 및 설정을 추가했습니다.

아래 블로그들을 보면 추가로 클랜 태스크를 실행하는 것 같은데 예전에 [프레디께서 공유해주셨던 자료](https://github.com/Im-D/your-voice-back/commit/fd2ee911a7f6acf74305a5fde77fde00f3778134)를 참고해보면 해당 태스크 실행 없이도 잘 동작하는 것 같아 일단 해당 부분만 추가하였습니다.

- https://jojoldu.tistory.com/538
- http://honeymon.io/tech/2020/07/09/gradle-annotation-processor-with-querydsl.html

✅ Closes: #189