### PR TITLE
[Freddie] REST docs에 request parameter 예외 상황 표현

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/user/controller/EmailValidationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/EmailValidationRequest.java
@@ -1,0 +1,20 @@
+package com.postsquad.scoup.web.user.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class EmailValidationRequest {
+
+    @NotEmpty
+    @Email
+    private String email;
+}

--- a/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.postsquad.scoup.web.user.controller;
 import com.postsquad.scoup.web.common.DefaultPostResponse;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
+import com.postsquad.scoup.web.user.controller.request.NicknameValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -10,14 +11,11 @@ import com.postsquad.scoup.web.user.service.SignUpFailedException;
 import com.postsquad.scoup.web.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import javax.validation.constraints.NotEmpty;
 
 @RequiredArgsConstructor
-@Validated
 @RequestMapping("/users")
 @RestController
 public class UserController {
@@ -43,7 +41,7 @@ public class UserController {
     }
 
     @GetMapping("/validate/nickname")
-    public NicknameValidationResponse validateNickname(@RequestParam @NotEmpty String nickname) {
-        return userService.validateNickname(nickname);
+    public NicknameValidationResponse validateNickname(@Valid NicknameValidationRequest nicknameValidationRequest) {
+        return userService.validateNickname(nicknameValidationRequest);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
@@ -38,8 +38,8 @@ public class UserController {
     }
 
     @GetMapping("/validate/email")
-    public EmailValidationResponse validateEmail(@RequestParam @NotEmpty @Email String email) {
-        return userService.validateEmail(email);
+    public EmailValidationResponse validateEmail(@Valid EmailValidationRequest emailValidationRequest) {
+        return userService.validateEmail(emailValidationRequest);
     }
 
     @GetMapping("/validate/nickname")

--- a/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.postsquad.scoup.web.user.controller;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -13,7 +14,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/postsquad/scoup/web/user/controller/request/EmailValidationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/request/EmailValidationRequest.java
@@ -1,4 +1,4 @@
-package com.postsquad.scoup.web.user.controller;
+package com.postsquad.scoup.web.user.controller.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/postsquad/scoup/web/user/controller/request/NicknameValidationRequest.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/request/NicknameValidationRequest.java
@@ -1,0 +1,18 @@
+package com.postsquad.scoup.web.user.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Data
+public class NicknameValidationRequest {
+
+    @NotEmpty
+    private String nickname;
+}

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.postsquad.scoup.web.user.service;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
 import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
+import com.postsquad.scoup.web.user.controller.request.NicknameValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -44,8 +45,8 @@ public class UserService {
         return EmailValidationResponse.valueOf(false);
     }
 
-    public NicknameValidationResponse validateNickname(String nickname) {
-        if (userRepository.findByNickname(nickname).isPresent()) {
+    public NicknameValidationResponse validateNickname(NicknameValidationRequest nicknameValidationRequest) {
+        if (userRepository.findByNickname(nicknameValidationRequest.getNickname()).isPresent()) {
             return NicknameValidationResponse.valueOf(true);
         }
         return NicknameValidationResponse.valueOf(false);

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.postsquad.scoup.web.user.service;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
-import com.postsquad.scoup.web.user.controller.EmailValidationRequest;
+import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;

--- a/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
+++ b/src/main/java/com/postsquad/scoup/web/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.user.service;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
+import com.postsquad.scoup.web.user.controller.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -36,8 +37,8 @@ public class UserService {
                                   .build();
     }
 
-    public EmailValidationResponse validateEmail(String email) {
-        if (userRepository.findByEmail(email).isPresent()) {
+    public EmailValidationResponse validateEmail(EmailValidationRequest emailValidationRequest) {
+        if (userRepository.findByEmail(emailValidationRequest.getEmail()).isPresent()) {
             return EmailValidationResponse.valueOf(true);
         }
         return EmailValidationResponse.valueOf(false);

--- a/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
+++ b/src/test/java/com/postsquad/scoup/web/AcceptanceTestBase.java
@@ -21,6 +21,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.restdocs.snippet.Attributes.Attribute;
 import org.springframework.restdocs.snippet.Snippet;
 
@@ -29,6 +30,7 @@ import java.util.List;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
@@ -116,6 +118,17 @@ public class AcceptanceTestBase {
         String camelCasePath = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, path);
         Attribute constraints = key("constraints").value(constraintDescriptions.descriptionsForProperty(camelCasePath));
         FieldDescriptor fieldWithPathAndConstraints = fieldWithPath.attributes(constraints);
+
+        return fieldWithPathAndConstraints;
+    }
+
+    protected static ParameterDescriptor parameterWithNameAndConstraints(String path, Class<?> clazz) {
+        ParameterDescriptor parameterWithName = parameterWithName(path);
+
+        ConstraintDescriptions constraintDescriptions = new ConstraintDescriptions(clazz);
+        String camelCasePath = CaseFormat.LOWER_UNDERSCORE.to(CaseFormat.LOWER_CAMEL, path);
+        Attribute constraints = key("constraints").value(constraintDescriptions.descriptionsForProperty(camelCasePath));
+        ParameterDescriptor fieldWithPathAndConstraints = parameterWithName.attributes(constraints);
 
         return fieldWithPathAndConstraints;
     }

--- a/src/test/java/com/postsquad/scoup/web/schedule/ScheduleCandidateAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/schedule/ScheduleCandidateAcceptanceTest.java
@@ -44,9 +44,9 @@ class ScheduleCandidateAcceptanceTest extends AcceptanceTestBase {
     );
 
     private static final Snippet SCHEDULE_CANDIDATE_READ_ALL_REQUEST_FIELDS = requestParameters(
-            parameterWithName("start_date")
+            parameterWithNameAndConstraints("start_date", ScheduleCandidateReadRequest.class)
                     .description("스케줄 후보 조회 범위 시작점"),
-            parameterWithName("end_date")
+            parameterWithNameAndConstraints("end_date", ScheduleCandidateReadRequest.class)
                     .description("스케줄 후보 조회 범위 종료시점")
     );
 

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.postsquad.scoup.web.AcceptanceTestBase;
 import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.common.DefaultPostResponse;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
+import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -86,7 +87,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
     );
 
     private static final Snippet EMAIL_VALIDATION_REQUEST_PARAMS = requestParameters(
-            parameterWithName("email").description("검증 이메일")
+            parameterWithNameAndConstraints("email", EmailValidationRequest.class)
+                    .description("검증 이메일")
     );
 
     private static final Snippet EMAIL_VALIDATION_RESPONSE_FIELDS = responseFields(

--- a/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/UserAcceptanceTest.java
@@ -5,6 +5,7 @@ import com.postsquad.scoup.web.auth.OAuthType;
 import com.postsquad.scoup.web.common.DefaultPostResponse;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
+import com.postsquad.scoup.web.user.controller.request.NicknameValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.controller.response.NicknameValidationResponse;
@@ -30,7 +31,6 @@ import java.util.List;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
@@ -98,7 +98,8 @@ class UserAcceptanceTest extends AcceptanceTestBase {
     );
 
     private static final Snippet NICKNAME_VALIDATION_REQUEST_PARAMS = requestParameters(
-            parameterWithName("nickname").description("검증 닉네임")
+            parameterWithNameAndConstraints("nickname", NicknameValidationRequest.class)
+                    .description("검증 닉네임")
     );
 
     private static final Snippet NICKNAME_VALIDATION_RESPONSE_FIELDS = responseFields(

--- a/src/test/java/com/postsquad/scoup/web/user/provider/ValidateEmailRequestParamProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/user/provider/ValidateEmailRequestParamProvider.java
@@ -20,7 +20,7 @@ public class ValidateEmailRequestParamProvider implements ArgumentsProvider {
                         ErrorResponse.builder()
                                      .statusCode(HttpStatus.BAD_REQUEST.value())
                                      .message("Method argument not valid.")
-                                     .errors(Collections.singletonList("validateEmail.email: must not be empty"))
+                                     .errors(Collections.singletonList("email: must not be empty"))
                                      .build()
                 ), Arguments.of(
                         "실패: null",
@@ -28,7 +28,7 @@ public class ValidateEmailRequestParamProvider implements ArgumentsProvider {
                         ErrorResponse.builder()
                                      .statusCode(HttpStatus.BAD_REQUEST.value())
                                      .message("Method argument not valid.")
-                                     .errors(Collections.singletonList("validateEmail.email: must not be empty"))
+                                     .errors(Collections.singletonList("email: must not be empty"))
                                      .build()
                 ), Arguments.of(
                         "실패: 이메일 형식",
@@ -36,7 +36,7 @@ public class ValidateEmailRequestParamProvider implements ArgumentsProvider {
                         ErrorResponse.builder()
                                      .statusCode(HttpStatus.BAD_REQUEST.value())
                                      .message("Method argument not valid.")
-                                     .errors(Collections.singletonList("validateEmail.email: must be a well-formed email address"))
+                                     .errors(Collections.singletonList("email: must be a well-formed email address"))
                                      .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/provider/ValidateNicknameRequestParamProvider.java
+++ b/src/test/java/com/postsquad/scoup/web/user/provider/ValidateNicknameRequestParamProvider.java
@@ -19,7 +19,7 @@ public class ValidateNicknameRequestParamProvider implements ArgumentsProvider {
                         ErrorResponse.builder()
                                      .statusCode(HttpStatus.BAD_REQUEST.value())
                                      .message("Method argument not valid.")
-                                     .errors(Collections.singletonList("validateNickname.nickname: must not be empty"))
+                                     .errors(Collections.singletonList("nickname: must not be empty"))
                                      .build()
                 ),
                 Arguments.of(
@@ -28,7 +28,7 @@ public class ValidateNicknameRequestParamProvider implements ArgumentsProvider {
                         ErrorResponse.builder()
                                      .statusCode(HttpStatus.BAD_REQUEST.value())
                                      .message("Method argument not valid.")
-                                     .errors(Collections.singletonList("validateNickname.nickname: must not be empty"))
+                                     .errors(Collections.singletonList("nickname: must not be empty"))
                                      .build()
                 )
         );

--- a/src/test/java/com/postsquad/scoup/web/user/service/UserServiceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/service/UserServiceTest.java
@@ -1,6 +1,6 @@
 package com.postsquad.scoup.web.user.service;
 
-import com.postsquad.scoup.web.user.controller.EmailValidationRequest;
+import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.domain.User;

--- a/src/test/java/com/postsquad/scoup/web/user/service/UserServiceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package com.postsquad.scoup.web.user.service;
 
+import com.postsquad.scoup.web.user.controller.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.SignUpRequest;
 import com.postsquad.scoup.web.user.controller.response.EmailValidationResponse;
 import com.postsquad.scoup.web.user.domain.User;
@@ -62,9 +63,9 @@ public class UserServiceTest {
 
     @ParameterizedTest
     @MethodSource("validateEmailProvider")
-    public void validateEmail(String email, EmailValidationResponse expected) {
+    public void validateEmail(EmailValidationRequest emailValidationRequest, EmailValidationResponse expected) {
         // when
-        EmailValidationResponse response = userService.validateEmail(email);
+        EmailValidationResponse response = userService.validateEmail(emailValidationRequest);
 
         // then
         then(response).usingRecursiveComparison()
@@ -73,8 +74,18 @@ public class UserServiceTest {
 
     static Stream<Arguments> validateEmailProvider() {
         return Stream.of(
-                Arguments.of("email@email.com", EmailValidationResponse.valueOf(true)),
-                Arguments.of("notExistingEmail@email.com", EmailValidationResponse.valueOf(false))
+                Arguments.of(
+                        EmailValidationRequest.builder()
+                                              .email("email@email.com")
+                                              .build(),
+                        EmailValidationResponse.valueOf(true)
+                ),
+                Arguments.of(
+                        EmailValidationRequest.builder()
+                                              .email("notExistingEmail@email.com")
+                                              .build(),
+                        EmailValidationResponse.valueOf(false)
+                )
         );
     }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parameters.snippet
@@ -1,0 +1,12 @@
+[%autowidth.stretch]
+|===
+|Parameter|Description|constraints
+
+{{#parameters}}
+|`{{name}}`
+|{{description}}
+|{{#constraints}}· {{.}} +
+{{/constraints}}
+{{/parameters}}
+
+|===


### PR DESCRIPTION
REST Docs로 DTO 제약사항을 스니펫 객체에 추가하려면 클래스에 묶여있어야 합니다.
#201 에서 Request Parameter에서 객체로도 validation이 가능하도록 수정했고, 이를 이용했습니다.

그리고 이를 문서로 나타내기 위해 스니펫 템플릿을 추가했습니다.

--- 
반영 후에 아래사항 작업 예정입니다
- 스케줄후보 조회 인수테스트 validation 테스트 누락되어 있음
- 닉네임 검증 서비스 테스트 누락되어 있음