### PR TITLE
[Freddie] SocialAuthenticationResponse의 oauthType 수정

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/auth/controller/response/SocialAuthenticationResponse.java
+++ b/src/main/java/com/postsquad/scoup/web/auth/controller/response/SocialAuthenticationResponse.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Getter
 public class SocialAuthenticationResponse {
 
-    private OAuthType oAuthType;
+    private OAuthType oauthType;
 
     private String socialServiceId;
 

--- a/src/main/java/com/postsquad/scoup/web/auth/mapper/SocialAuthenticationResponseMapper.java
+++ b/src/main/java/com/postsquad/scoup/web/auth/mapper/SocialAuthenticationResponseMapper.java
@@ -16,7 +16,7 @@ public interface SocialAuthenticationResponseMapper {
     SocialAuthenticationResponseMapper INSTANCE = Mappers.getMapper(SocialAuthenticationResponseMapper.class);
 
     @Mappings({
-            @Mapping(target = "oAuthType", source = "type"),
+            @Mapping(target = "oauthType", source = "type"),
             @Mapping(target = "socialServiceId", source = "gitHubUserResponse.id"),
             @Mapping(target = "name", source = "gitHubUserResponse.name"),
             @Mapping(target = "email", source = "gitHubUserResponse.email"),
@@ -25,7 +25,7 @@ public interface SocialAuthenticationResponseMapper {
     SocialAuthenticationResponse map(GitHubUserResponse gitHubUserResponse, OAuthType type);
 
     @Mappings({
-            @Mapping(target = "oAuthType", source = "type"),
+            @Mapping(target = "oauthType", source = "type"),
             @Mapping(target = "socialServiceId", source = "kakaoUserResponse.id"),
             @Mapping(target = "name", source = "kakaoUserResponse.kakaoAccount.profile.nickname"),
             @Mapping(target = "email", source = "kakaoUserResponse.kakaoAccount.email"),
@@ -34,7 +34,7 @@ public interface SocialAuthenticationResponseMapper {
     SocialAuthenticationResponse map(KakaoUserResponse kakaoUserResponse, OAuthType type);
 
     @Mappings({
-            @Mapping(target = "oAuthType", source = "type"),
+            @Mapping(target = "oauthType", source = "type"),
             @Mapping(target = "socialServiceId", source = "googleUserResponse.sub"),
             @Mapping(target = "name", source = "googleUserResponse.name"),
             @Mapping(target = "email", source = "googleUserResponse.email"),

--- a/src/test/java/com/postsquad/scoup/web/auth/OAuthAcceptanceTest.java
+++ b/src/test/java/com/postsquad/scoup/web/auth/OAuthAcceptanceTest.java
@@ -56,13 +56,13 @@ class OAuthAcceptanceTest extends AcceptanceTestBase {
         return Stream.of(
                 Arguments.of(
                         "성공",
-                        SocialAuthenticationResponse
-                                .builder()
-                                .socialServiceId("68000537")
-                                .name("JiSun Lim")
-                                .email("jisunlim818@gmail.com")
-                                .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
-                                .build()
+                        SocialAuthenticationResponse.builder()
+                                                    .oauthType(OAuthType.GITHUB)
+                                                    .socialServiceId("68000537")
+                                                    .name("JiSun Lim")
+                                                    .email("jisunlim818@gmail.com")
+                                                    .avatarUrl("https://avatars.githubusercontent.com/u/68000537?v=4")
+                                                    .build()
                 )
         );
     }


### PR DESCRIPTION
oAuthType -> oauthType 으로 수정했습니다.
REST Docs 만지면서 비슷한 문제 있었는데, 별개로 잭슨이 제대로 동작하지 않고 있었습니다.  jsonproperty 어노테이션도 붙어있지 않아 o_auth_type으로 찾고 있었던 것 같네요.

수정하면서 인수테스트에서 제대로 변환되지 않았던 문제를 수정했습니다.
@janeljs 혹시 해당 테스트케이스에 oauthtype null로 되어있는게 의도된 것인지 커멘트 부탁 드릴게요!