### PR TITLE
[Freddie] Signin interceptor white list로 변경

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -23,10 +23,6 @@ import java.util.List;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final String[] SIGNIN_PATH_TO_INCLUDE = {
-            "/groups/**"
-    };
-
     private final SignInInterceptor signInInterceptor;
 
     private final RequestParameterArgumentResolver requestParameterArgumentResolver;
@@ -60,6 +56,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(signInInterceptor)
-                .addPathPatterns(SIGNIN_PATH_TO_INCLUDE);
+                .addPathPatterns(signInInterceptor.pathToInclude())
+                .excludePathPatterns(signInInterceptor.pathToExclude());
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
+++ b/src/main/java/com/postsquad/scoup/web/config/WebConfig.java
@@ -23,16 +23,8 @@ import java.util.List;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final String[] SIGNIN_PATH_TO_EXCLUDE = {
-            "/sign-in/**",
-            "/users/**",
-            "/oauth/**",
-            "/h2-console/**",
-            "/swagger-ui.html",
-            "/v2/api-docs",
-            "/swagger-resources/**",
-            "/webjars/**",
-            "/docs/**"
+    private final String[] SIGNIN_PATH_TO_INCLUDE = {
+            "/groups/**"
     };
 
     private final SignInInterceptor signInInterceptor;
@@ -68,7 +60,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(signInInterceptor)
-                .addPathPatterns("/**")
-                .excludePathPatterns(SIGNIN_PATH_TO_EXCLUDE);
+                .addPathPatterns(SIGNIN_PATH_TO_INCLUDE);
     }
 }

--- a/src/main/java/com/postsquad/scoup/web/signin/controller/SignInInterceptor.java
+++ b/src/main/java/com/postsquad/scoup/web/signin/controller/SignInInterceptor.java
@@ -11,10 +11,17 @@ import org.springframework.web.servlet.HandlerInterceptor;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Component
 public class SignInInterceptor implements HandlerInterceptor {
+
+    private static final List<String> PATH_TO_INCLUDE = List.of(
+            "/groups/**"
+    );
+
+    private static final List<String> PATH_TO_EXCLUDE = List.of();
 
     private final UserRepository userRepository;
 
@@ -31,5 +38,13 @@ public class SignInInterceptor implements HandlerInterceptor {
         request.setAttribute("user", user);
 
         return true;
+    }
+
+    public List<String> pathToInclude() {
+        return PATH_TO_INCLUDE;
+    }
+
+    public List<String> pathToExclude() {
+        return PATH_TO_EXCLUDE;
     }
 }


### PR DESCRIPTION
현재 로그인 검증을 해야하는 API는 `/groups` 의 하위에 모여있어서 `groups/**`로 설정해줬습니다.

경로는 `SigninInterceptor`에 모아줬고, 프로퍼티로 변경될 경우에도 코드 수정이 없도록 메소드로 호출하도록 해줬습니다.