### PR TITLE
[Freddie] QueryParam 어노테이션이 붙은 파라미터만 바인딩하도록 리졸버 수정

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/common/QueryParam.java
+++ b/src/main/java/com/postsquad/scoup/web/common/QueryParam.java
@@ -1,0 +1,11 @@
+package com.postsquad.scoup.web.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryParam {
+}

--- a/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
+++ b/src/main/java/com/postsquad/scoup/web/config/RequestParameterArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.config;
 
 import com.postsquad.scoup.web.common.ObjectMapperUtils;
+import com.postsquad.scoup.web.common.QueryParam;
 import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -14,6 +15,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestResponseBodyMethodProcessor;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * 리퀘스트 파라미터(@RequestParam으로 바인딩)에 사용되는 객체를 ServletRequestDataBinder 대신 처리한다.
@@ -38,7 +40,7 @@ public class RequestParameterArgumentResolver extends RequestResponseBodyMethodP
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return !parameter.getParameterType().isPrimitive();
+        return Objects.nonNull(parameter.getParameterAnnotation(QueryParam.class));
     }
 
     @Override

--- a/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
+++ b/src/main/java/com/postsquad/scoup/web/group/controller/GroupController.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.group.controller;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
+import com.postsquad.scoup.web.common.QueryParam;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.group.controller.request.GroupCreationRequest;
 import com.postsquad.scoup.web.group.controller.request.GroupModificationRequest;
@@ -61,7 +62,7 @@ public class GroupController {
     }
 
     @GetMapping("/validate/group-name")
-    public GroupValidationResponse validateGroupName(@Valid GroupValidationRequest groupValidationRequest) {
+    public GroupValidationResponse validateGroupName(@QueryParam @Valid GroupValidationRequest groupValidationRequest) {
         return GroupValidationResponse.builder()
                                       .isExistingName(true)
                                       .build();

--- a/src/main/java/com/postsquad/scoup/web/schedule/controller/ScheduleCandidateController.java
+++ b/src/main/java/com/postsquad/scoup/web/schedule/controller/ScheduleCandidateController.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.schedule.controller;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
+import com.postsquad.scoup.web.common.QueryParam;
 import com.postsquad.scoup.web.schedule.controller.request.ScheduleCandidateCreationRequest;
 import com.postsquad.scoup.web.schedule.controller.request.ScheduleCandidateReadRequest;
 import com.postsquad.scoup.web.schedule.controller.response.ScheduleCandidateReadAllResponses;
@@ -16,7 +17,7 @@ public class ScheduleCandidateController {
     private final ScheduleCandidateService scheduleCandidateService;
 
     @GetMapping("/groups/{groupId}/schedule-candidates")
-    public ScheduleCandidateReadAllResponses readAll(@PathVariable long groupId, ScheduleCandidateReadRequest givenScheduleCandidateReadRequest) {
+    public ScheduleCandidateReadAllResponses readAll(@PathVariable long groupId, @QueryParam ScheduleCandidateReadRequest givenScheduleCandidateReadRequest) {
         return scheduleCandidateService.readAll(groupId, givenScheduleCandidateReadRequest);
     }
 

--- a/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
+++ b/src/main/java/com/postsquad/scoup/web/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.postsquad.scoup.web.user.controller;
 
 import com.postsquad.scoup.web.common.DefaultPostResponse;
+import com.postsquad.scoup.web.common.QueryParam;
 import com.postsquad.scoup.web.error.controller.response.ErrorResponse;
 import com.postsquad.scoup.web.user.controller.request.EmailValidationRequest;
 import com.postsquad.scoup.web.user.controller.request.NicknameValidationRequest;
@@ -36,12 +37,12 @@ public class UserController {
     }
 
     @GetMapping("/validate/email")
-    public EmailValidationResponse validateEmail(@Valid EmailValidationRequest emailValidationRequest) {
+    public EmailValidationResponse validateEmail(@QueryParam @Valid EmailValidationRequest emailValidationRequest) {
         return userService.validateEmail(emailValidationRequest);
     }
 
     @GetMapping("/validate/nickname")
-    public NicknameValidationResponse validateNickname(@Valid NicknameValidationRequest nicknameValidationRequest) {
+    public NicknameValidationResponse validateNickname(@QueryParam @Valid NicknameValidationRequest nicknameValidationRequest) {
         return userService.validateNickname(nicknameValidationRequest);
     }
 }


### PR DESCRIPTION
QueryParam 어노테이션을 추가하고, QueryParam 어노테이션이 붙은 핸들러 파라미터만 RequestParameterArgumentResolver로 처리하도록 했습니다.

기존에는 단순히 기본타입인지 확인하여 처리했는데, path parameter를 객체로 묶으려고 할때 문제가 발생합니다.
> path parameter를 객체로 묶으려는 이유는 REST Docs 표현에 객체가 유리하기 때문입니다. 이후에 path parameter도 별개의 DTO로 묶어주는 작업을 하려고 하는데, 의견 부탁드립니다!

이외에도 멀티파트 사용 시 문제가 발생할 것으로 예상했는데 아예 조건을 줘버리면서 우회할 수 있을 것 같습니다.

추가로 테스트 통과할 수 있도록 현재 바인딩 되고 있는 핸들러 파라미터에 QueryParam 어노테이션 추가