### PR TITLE
[Freddie] REST Docs 스니펫 생성기

### DIFF
--- a/src/main/java/com/postsquad/scoup/web/common/FieldDescription.java
+++ b/src/main/java/com/postsquad/scoup/web/common/FieldDescription.java
@@ -1,0 +1,15 @@
+package com.postsquad.scoup.web.common;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface FieldDescription {
+    String value();
+
+    boolean optional() default false;
+}

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -86,6 +86,14 @@ public class SnippetGenerator<T> {
         );
     }
 
+    public Snippet pathParameters() {
+        return RequestDocumentation.pathParameters(
+                fields.stream()
+                      .map(this::parameterDescriptorFrom)
+                      .collect(Collectors.toList())
+        );
+    }
+
     private ParameterDescriptor parameterDescriptorFrom(Field field) {
         String path = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, field.getName());
         ParameterDescriptor parameterWithName = parameterWithName(path);

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -29,6 +29,10 @@ public class SnippetGenerator<T> {
         return PayloadDocumentation.requestFields(fieldDescriptors());
     }
 
+    public Snippet responseFields() {
+        return PayloadDocumentation.responseFields(fieldDescriptors());
+    }
+
     private List<FieldDescriptor> fieldDescriptors() {
         List<Field> fields = fieldsFrom();
 

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -1,0 +1,94 @@
+package com.postsquad.scoup.web.test.restdocs;
+
+import com.google.common.base.CaseFormat;
+import com.postsquad.scoup.web.common.FieldDescription;
+import com.postsquad.scoup.web.signin.controller.request.SignInRequest;
+import org.springframework.restdocs.constraints.ConstraintDescriptions;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.snippet.Attributes;
+import org.springframework.restdocs.snippet.Snippet;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public class SnippetGenerator<T> {
+
+    private Class<T> clazz;
+
+    public SnippetGenerator(Class<T> clazz) {
+        this.clazz = clazz;
+    }
+
+    public Snippet requestFields() {
+        return PayloadDocumentation.requestFields(fieldDescriptors());
+    }
+
+    private List<FieldDescriptor> fieldDescriptors() {
+        List<Field> fields = fieldsFrom();
+
+        return fields.stream()
+                     .map(this::fieldToDescriptor)
+                     .collect(Collectors.toList());
+    }
+
+    private List<Field> fieldsFrom() {
+        List<Field> fields = new ArrayList<>();
+
+        for (Class<?> superClass = clazz.getSuperclass(); superClass != Object.class; superClass = superClass.getSuperclass()) {
+            fields.addAll(List.of(superClass.getDeclaredFields()));
+        }
+
+        fields.addAll(List.of(clazz.getDeclaredFields()));
+
+        return fields;
+    }
+
+    private FieldDescriptor fieldToDescriptor(Field field) {
+        String path = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, field.getName());
+        FieldDescriptor fieldWithPath = fieldWithPath(path);
+
+        fieldWithPath.type(typeFrom(field));
+
+        fieldWithPath.description(descriptionFrom(field, path));
+
+        if (isOptional(field)) {
+            fieldWithPath.optional();
+        }
+
+        fieldWithPath.attributes(constraintAttributeFrom(field));
+
+        return fieldWithPath;
+    }
+
+    private String typeFrom(Field field) {
+        return field.getType().getSimpleName();
+    }
+
+    private String descriptionFrom(Field field, String defaultDescription) {
+        FieldDescription fieldDescription = field.getAnnotation(FieldDescription.class);
+
+        if (Objects.nonNull(fieldDescription)) {
+            return Objects.toString(fieldDescription.value(), defaultDescription);
+        }
+
+        return defaultDescription;
+    }
+
+    private boolean isOptional(Field field) {
+        FieldDescription fieldDescription = field.getAnnotation(FieldDescription.class);
+        return Objects.nonNull(fieldDescription) && fieldDescription.optional();
+    }
+
+    private Attributes.Attribute constraintAttributeFrom(Field field) {
+        ConstraintDescriptions constraintDescriptions = new ConstraintDescriptions(clazz);
+
+        return key("constraints").value(constraintDescriptions.descriptionsForProperty(field.getName()));
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -2,7 +2,6 @@ package com.postsquad.scoup.web.test.restdocs;
 
 import com.google.common.base.CaseFormat;
 import com.postsquad.scoup.web.common.FieldDescription;
-import com.postsquad.scoup.web.signin.controller.request.SignInRequest;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.PayloadDocumentation;

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -5,6 +5,8 @@ import com.postsquad.scoup.web.common.FieldDescription;
 import org.springframework.restdocs.constraints.ConstraintDescriptions;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.restdocs.snippet.Snippet;
 
@@ -15,6 +17,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
 public class SnippetGenerator<T> {
@@ -37,8 +40,16 @@ public class SnippetGenerator<T> {
         List<Field> fields = fieldsFrom();
 
         return fields.stream()
-                     .map(this::fieldToDescriptor)
+                     .map(this::fieldDescriptorFrom)
                      .collect(Collectors.toList());
+    }
+
+    public Snippet requestParameters() {
+        return RequestDocumentation.requestParameters(
+                fieldsFrom().stream()
+                            .map(this::parameterDescriptorFrom)
+                            .collect(Collectors.toList())
+        );
     }
 
     private List<Field> fieldsFrom() {
@@ -53,7 +64,7 @@ public class SnippetGenerator<T> {
         return fields;
     }
 
-    private FieldDescriptor fieldToDescriptor(Field field) {
+    private FieldDescriptor fieldDescriptorFrom(Field field) {
         String path = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, field.getName());
         FieldDescriptor fieldWithPath = fieldWithPath(path);
 
@@ -68,6 +79,21 @@ public class SnippetGenerator<T> {
         fieldWithPath.attributes(constraintAttributeFrom(field));
 
         return fieldWithPath;
+    }
+
+    private ParameterDescriptor parameterDescriptorFrom(Field field) {
+        String path = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, field.getName());
+        ParameterDescriptor parameterWithName = parameterWithName(path);
+
+        parameterWithName.description(descriptionFrom(field, path));
+
+        if (isOptional(field)) {
+            parameterWithName.optional();
+        }
+
+        parameterWithName.attributes(constraintAttributeFrom(field));
+
+        return parameterWithName;
     }
 
     private String typeFrom(Field field) {

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGenerator.java
@@ -79,19 +79,17 @@ public class SnippetGenerator<T> {
     }
 
     public Snippet requestParameters() {
-        return RequestDocumentation.requestParameters(
-                fields.stream()
-                      .map(this::parameterDescriptorFrom)
-                      .collect(Collectors.toList())
-        );
+        return RequestDocumentation.requestParameters(parameterDescriptors());
     }
 
     public Snippet pathParameters() {
-        return RequestDocumentation.pathParameters(
-                fields.stream()
-                      .map(this::parameterDescriptorFrom)
-                      .collect(Collectors.toList())
-        );
+        return RequestDocumentation.pathParameters(parameterDescriptors());
+    }
+
+    private List<ParameterDescriptor> parameterDescriptors() {
+        return fields.stream()
+                     .map(this::parameterDescriptorFrom)
+                     .collect(Collectors.toList());
     }
 
     private ParameterDescriptor parameterDescriptorFrom(Field field) {

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
@@ -102,4 +102,26 @@ class SnippetGeneratorTest {
                 .usingRecursiveComparison()
                 .isEqualTo(expectedRequestParametersSnippet);
     }
+
+    @Test
+    void pathParameters() {
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = SnippetGenerator.from(TestDto.class);
+        Snippet expectedRequestParametersSnippet = RequestDocumentation.pathParameters(
+                parameterWithName("id")
+                        .description("description for id")
+                        .attributes(key("constraints").value(List.of())),
+                parameterWithName("name")
+                        .description("description for name")
+                        .attributes(key("constraints").value(List.of(
+                                "Must not be empty",
+                                "Size must be between 1 and 5 inclusive"
+                        )))
+                        .optional()
+        );
+
+        Snippet actualRequestParametersSnippet = testDtoSnippetGenerator.pathParameters();
+        assertThat(actualRequestParametersSnippet)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequestParametersSnippet);
+    }
 }

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
@@ -1,0 +1,56 @@
+package com.postsquad.scoup.web.test.restdocs;
+
+import com.postsquad.scoup.web.common.FieldDescription;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.snippet.Snippet;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+class SnippetGeneratorTest {
+
+    static class TestSuperDto {
+
+        @FieldDescription("description for id")
+        private int id;
+    }
+
+    static class TestDto extends TestSuperDto {
+
+        @FieldDescription(value = "description for name", optional = true)
+        @NotEmpty
+        @Size(min = 1, max = 5)
+        private String name;
+    }
+
+    @Test
+    void requestFields() {
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        Snippet expectedRequestFieldsSnippet = PayloadDocumentation.requestFields(
+                fieldWithPath("id")
+                        .type("int")
+                        .description("description for id")
+                        .attributes(key("constraints").value(List.of())),
+                fieldWithPath("name")
+                        .type("String")
+                        .description("description for name")
+                        .attributes(key("constraints").value(List.of(
+                                "Must not be empty",
+                                "Size must be between 1 and 5 inclusive"
+                        )))
+                        .optional()
+        );
+
+        Snippet actualRequestFieldsSnippet = testDtoSnippetGenerator.requestFields();
+
+        assertThat(actualRequestFieldsSnippet)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequestFieldsSnippet);
+    }
+}

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
@@ -3,6 +3,7 @@ package com.postsquad.scoup.web.test.restdocs;
 import com.postsquad.scoup.web.common.FieldDescription;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.PayloadDocumentation;
+import org.springframework.restdocs.request.RequestDocumentation;
 import org.springframework.restdocs.snippet.Snippet;
 
 import javax.validation.constraints.NotEmpty;
@@ -11,6 +12,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.snippet.Attributes.key;
 
 class SnippetGeneratorTest {
@@ -77,5 +79,27 @@ class SnippetGeneratorTest {
         assertThat(actualRequestFieldsSnippet)
                 .usingRecursiveComparison()
                 .isEqualTo(expectedRequestFieldsSnippet);
+    }
+
+    @Test
+    void requestParameters() {
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        Snippet expectedRequestParametersSnippet = RequestDocumentation.requestParameters(
+                parameterWithName("id")
+                        .description("description for id")
+                        .attributes(key("constraints").value(List.of())),
+                parameterWithName("name")
+                        .description("description for name")
+                        .attributes(key("constraints").value(List.of(
+                                "Must not be empty",
+                                "Size must be between 1 and 5 inclusive"
+                        )))
+                        .optional()
+        );
+
+        Snippet actualRequestParametersSnippet = testDtoSnippetGenerator.requestParameters();
+        assertThat(actualRequestParametersSnippet)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequestParametersSnippet);
     }
 }

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
@@ -33,7 +33,7 @@ class SnippetGeneratorTest {
 
     @Test
     void requestFields() {
-        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = SnippetGenerator.from(TestDto.class);
         Snippet expectedRequestFieldsSnippet = PayloadDocumentation.requestFields(
                 fieldWithPath("id")
                         .type("int")
@@ -58,7 +58,7 @@ class SnippetGeneratorTest {
 
     @Test
     void responseFields() {
-        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = SnippetGenerator.from(TestDto.class);
         Snippet expectedRequestFieldsSnippet = PayloadDocumentation.responseFields(
                 fieldWithPath("id")
                         .type("int")
@@ -83,7 +83,7 @@ class SnippetGeneratorTest {
 
     @Test
     void requestParameters() {
-        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = SnippetGenerator.from(TestDto.class);
         Snippet expectedRequestParametersSnippet = RequestDocumentation.requestParameters(
                 parameterWithName("id")
                         .description("description for id")

--- a/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
+++ b/src/test/java/com/postsquad/scoup/web/test/restdocs/SnippetGeneratorTest.java
@@ -53,4 +53,29 @@ class SnippetGeneratorTest {
                 .usingRecursiveComparison()
                 .isEqualTo(expectedRequestFieldsSnippet);
     }
+
+    @Test
+    void responseFields() {
+        SnippetGenerator<TestDto> testDtoSnippetGenerator = new SnippetGenerator<>(TestDto.class);
+        Snippet expectedRequestFieldsSnippet = PayloadDocumentation.responseFields(
+                fieldWithPath("id")
+                        .type("int")
+                        .description("description for id")
+                        .attributes(key("constraints").value(List.of())),
+                fieldWithPath("name")
+                        .type("String")
+                        .description("description for name")
+                        .attributes(key("constraints").value(List.of(
+                                "Must not be empty",
+                                "Size must be between 1 and 5 inclusive"
+                        )))
+                        .optional()
+        );
+
+        Snippet actualRequestFieldsSnippet = testDtoSnippetGenerator.responseFields();
+
+        assertThat(actualRequestFieldsSnippet)
+                .usingRecursiveComparison()
+                .isEqualTo(expectedRequestFieldsSnippet);
+    }
 }


### PR DESCRIPTION
close #232 

리플렉션으로 클래스의 필드들을 가져온 뒤 스니펫을 자동으로 만들어줍니다.

이 과정에서 설명을 표현하기 위해 FieldDescription 어노테이션을 추가했습니다.

아래와 같은 코드로 스니펫 생성 코드를 대체할 수 있고, 중복도 줄일 수 있을거라 생각합니다.

```java
SnippetGenerator<TestDto> snippetGenerator = SnippetGenerator.from(TestDto.class);
Snippet requestFieldsSnippet = snippetGenerator.requestFields();
```

사용법은 테스트 코드 보시고 궁금한점은 질문 남겨주세요!

리팩토링도 좀 해봤는데 일단 기능을 보시고 리팩토링은 피드백 받으며 진행하는게 좋을 것 같아서 먼저 PR 올릴게요